### PR TITLE
Expand the tool behaviour

### DIFF
--- a/src/main/java/net/errorcraft/itematic/access/component/type/ToolComponentAccess.java
+++ b/src/main/java/net/errorcraft/itematic/access/component/type/ToolComponentAccess.java
@@ -1,0 +1,14 @@
+package net.errorcraft.itematic.access.component.type;
+
+import net.minecraft.block.BlockState;
+import net.minecraft.item.ItemStack;
+
+public interface ToolComponentAccess {
+    default float itematic$getSpeed(ItemStack stack, BlockState state) {
+        return 0.0f;
+    }
+
+    default boolean itematic$isCorrectForDrops(ItemStack stack, BlockState state) {
+        return false;
+    }
+}

--- a/src/main/java/net/errorcraft/itematic/access/component/type/ToolComponentRuleAccess.java
+++ b/src/main/java/net/errorcraft/itematic/access/component/type/ToolComponentRuleAccess.java
@@ -1,0 +1,10 @@
+package net.errorcraft.itematic.access.component.type;
+
+import net.minecraft.block.BlockState;
+import net.minecraft.item.ItemStack;
+
+public interface ToolComponentRuleAccess {
+    default boolean itematic$matches(ItemStack stack, BlockState state) {
+        return false;
+    }
+}

--- a/src/main/java/net/errorcraft/itematic/component/type/ToolComponentRuleExtraFields.java
+++ b/src/main/java/net/errorcraft/itematic/component/type/ToolComponentRuleExtraFields.java
@@ -1,0 +1,21 @@
+package net.errorcraft.itematic.component.type;
+
+import com.mojang.serialization.MapCodec;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+import net.errorcraft.itematic.predicate.item.ItemPredicateUtil;
+import net.minecraft.network.RegistryByteBuf;
+import net.minecraft.network.codec.PacketCodec;
+import net.minecraft.network.codec.PacketCodecs;
+import net.minecraft.predicate.item.ItemPredicate;
+
+import java.util.Optional;
+
+public record ToolComponentRuleExtraFields(Optional<ItemPredicate> item) {
+    public static final MapCodec<ToolComponentRuleExtraFields> CODEC = RecordCodecBuilder.mapCodec(instance -> instance.group(
+        ItemPredicate.CODEC.optionalFieldOf("item").forGetter(ToolComponentRuleExtraFields::item)
+    ).apply(instance, ToolComponentRuleExtraFields::new));
+    public static final PacketCodec<RegistryByteBuf, ToolComponentRuleExtraFields> PACKET_CODEC = PacketCodec.tuple(
+        ItemPredicateUtil.PACKET_CODEC.collect(PacketCodecs::optional), ToolComponentRuleExtraFields::item,
+        ToolComponentRuleExtraFields::new
+    );
+}

--- a/src/main/java/net/errorcraft/itematic/mixin/component/type/ToolComponentExtender.java
+++ b/src/main/java/net/errorcraft/itematic/mixin/component/type/ToolComponentExtender.java
@@ -1,0 +1,218 @@
+package net.errorcraft.itematic.mixin.component.type;
+
+import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
+import com.mojang.datafixers.kinds.App;
+import com.mojang.datafixers.util.Function3;
+import com.mojang.datafixers.util.Pair;
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.MapCodec;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+import net.errorcraft.itematic.access.component.type.ToolComponentAccess;
+import net.errorcraft.itematic.access.component.type.ToolComponentRuleAccess;
+import net.errorcraft.itematic.component.type.ToolComponentRuleExtraFields;
+import net.errorcraft.itematic.serialization.ItematicCodecs;
+import net.minecraft.block.Block;
+import net.minecraft.block.BlockState;
+import net.minecraft.component.type.ToolComponent;
+import net.minecraft.item.ItemStack;
+import net.minecraft.network.RegistryByteBuf;
+import net.minecraft.network.codec.PacketCodec;
+import net.minecraft.network.codec.PacketCodecs;
+import net.minecraft.registry.entry.RegistryEntryList;
+import org.objectweb.asm.Opcodes;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyArg;
+import org.spongepowered.asm.mixin.injection.Redirect;
+import org.spongepowered.asm.mixin.injection.Slice;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Function;
+
+@Mixin(ToolComponent.class)
+public class ToolComponentExtender implements ToolComponentAccess {
+    @Shadow
+    @Final
+    private List<ToolComponent.Rule> rules;
+
+    @Shadow
+    @Final
+    private float defaultMiningSpeed;
+
+    @Override
+    public float itematic$getSpeed(ItemStack stack, BlockState state) {
+        for (ToolComponent.Rule rule : this.rules) {
+            if (rule.speed().isPresent() && rule.itematic$matches(stack, state)) {
+                return rule.speed().get();
+            }
+        }
+        return this.defaultMiningSpeed;
+    }
+
+    @Override
+    public boolean itematic$isCorrectForDrops(ItemStack stack, BlockState state) {
+        for (ToolComponent.Rule rule : this.rules) {
+            if (rule.correctForDrops().isPresent() && rule.itematic$matches(stack, state)) {
+                return rule.correctForDrops().get();
+            }
+        }
+        return false;
+    }
+
+    @Mixin(ToolComponent.Rule.class)
+    public static class RuleExtender implements ToolComponentRuleAccess {
+        @Shadow
+        @Final
+        RegistryEntryList<Block> blocks;
+
+        @Unique
+        private ToolComponentRuleExtraFields extraFields = new ToolComponentRuleExtraFields(Optional.empty());
+
+        @Redirect(
+            method = "method_58430",
+            at = @At(
+                value = "INVOKE",
+                target = "Lcom/mojang/serialization/Codec;fieldOf(Ljava/lang/String;)Lcom/mojang/serialization/MapCodec;",
+                remap = false
+            )
+        )
+        private static MapCodec<Optional<RegistryEntryList<Block>>> fieldOfBlocksMakeFieldOptional(Codec<RegistryEntryList<Block>> instance, String name) {
+            return instance.optionalFieldOf(name);
+        }
+
+        @ModifyArg(
+            method = "method_58430",
+            at = @At(
+                value = "INVOKE",
+                target = "Lcom/mojang/serialization/MapCodec;forGetter(Ljava/util/function/Function;)Lcom/mojang/serialization/codecs/RecordCodecBuilder;",
+                ordinal = 0,
+                remap = false
+            ),
+            slice = @Slice(
+                from = @At(
+                    value = "CONSTANT",
+                    args = "stringValue=blocks"
+                )
+            )
+        )
+        private static Function<ToolComponent.Rule, Optional<RegistryEntryList<Block>>> forGetterBlocksFieldReturnOptional(Function<ToolComponent.Rule, RegistryEntryList<Block>> getter) {
+            return tool -> Optional.ofNullable(getter.apply(tool));
+        }
+
+        @Redirect(
+            method = "method_58430",
+            at = @At(
+                value = "FIELD",
+                target = "Lnet/minecraft/util/dynamic/Codecs;POSITIVE_FLOAT:Lcom/mojang/serialization/Codec;",
+                opcode = Opcodes.GETSTATIC
+            )
+        )
+        private static Codec<Float> speedFieldAllowZero() {
+            return ItematicCodecs.NON_NEGATIVE_FLOAT;
+        }
+
+        @ModifyArg(
+            method = "method_58430",
+            at = @At(
+                value = "INVOKE",
+                target = "Lcom/mojang/datafixers/Products$P3;apply(Lcom/mojang/datafixers/kinds/Applicative;Lcom/mojang/datafixers/util/Function3;)Lcom/mojang/datafixers/kinds/App;",
+                remap = false
+            )
+        )
+        private static Function3<Optional<RegistryEntryList<Block>>, Optional<Float>, Optional<Boolean>, ToolComponent.Rule> applyCodecUseOptional(Function3<RegistryEntryList<Block>, Optional<Float>, Optional<Boolean>, ToolComponent.Rule> instance) {
+            return RuleExtender::create;
+        }
+
+        @ModifyArg(
+            method = "<clinit>",
+            at = @At(
+                value = "INVOKE",
+                target = "Lnet/minecraft/network/codec/PacketCodec;tuple(Lnet/minecraft/network/codec/PacketCodec;Ljava/util/function/Function;Lnet/minecraft/network/codec/PacketCodec;Ljava/util/function/Function;Lnet/minecraft/network/codec/PacketCodec;Ljava/util/function/Function;Lcom/mojang/datafixers/util/Function3;)Lnet/minecraft/network/codec/PacketCodec;"
+            )
+        )
+        private static Function3<Optional<RegistryEntryList<Block>>, Optional<Float>, Optional<Boolean>, ToolComponent.Rule> applyPacketCodecUseOptional(Function3<RegistryEntryList<Block>, Optional<Float>, Optional<Boolean>, ToolComponent.Rule> to) {
+            return RuleExtender::create;
+        }
+
+        @ModifyExpressionValue(
+            method = "<clinit>",
+            at = @At(
+                value = "INVOKE",
+                target = "Lnet/minecraft/network/codec/PacketCodecs;registryEntryList(Lnet/minecraft/registry/RegistryKey;)Lnet/minecraft/network/codec/PacketCodec;"
+            )
+        )
+        private static PacketCodec<RegistryByteBuf, Optional<RegistryEntryList<Block>>> makeBlocksFieldOptional(PacketCodec<RegistryByteBuf, RegistryEntryList<Block>> original) {
+            return original.collect(PacketCodecs::optional);
+        }
+
+        @ModifyArg(
+            method = "<clinit>",
+            at = @At(
+                value = "INVOKE",
+                target = "Lnet/minecraft/network/codec/PacketCodec;tuple(Lnet/minecraft/network/codec/PacketCodec;Ljava/util/function/Function;Lnet/minecraft/network/codec/PacketCodec;Ljava/util/function/Function;Lnet/minecraft/network/codec/PacketCodec;Ljava/util/function/Function;Lcom/mojang/datafixers/util/Function3;)Lnet/minecraft/network/codec/PacketCodec;",
+                ordinal = 0
+            ),
+            index = 1
+        )
+        private static Function<ToolComponent.Rule, Optional<RegistryEntryList<Block>>> getBlocksReturnOptional(Function<ToolComponent.Rule, RegistryEntryList<Block>> from1) {
+            return rule -> Optional.ofNullable(from1.apply(rule));
+        }
+
+        @Redirect(
+            method = "<clinit>",
+            at = @At(
+                value = "INVOKE",
+                target = "Lcom/mojang/serialization/codecs/RecordCodecBuilder;create(Ljava/util/function/Function;)Lcom/mojang/serialization/Codec;",
+                remap = false
+            )
+        )
+        private static Codec<ToolComponent.Rule> createCodecAddExtraFields(Function<RecordCodecBuilder.Instance<ToolComponent.Rule>, ? extends App<RecordCodecBuilder.Mu<ToolComponent.Rule>, ToolComponent.Rule>> builder) {
+            MapCodec<ToolComponent.Rule> mapCodec = RecordCodecBuilder.mapCodec(builder);
+            return mapCodec.dependent(ToolComponentRuleExtraFields.CODEC, rule -> Pair.of(
+                ((RuleExtender)(Object) rule).extraFields,
+                ToolComponentRuleExtraFields.CODEC
+            ), (rule, extraFields) -> {
+                ((RuleExtender)(Object) rule).extraFields = extraFields;
+                return rule;
+            }).codec();
+        }
+
+        @ModifyExpressionValue(
+            method = "<clinit>",
+            at = @At(
+                value = "INVOKE",
+                target = "Lnet/minecraft/network/codec/PacketCodec;tuple(Lnet/minecraft/network/codec/PacketCodec;Ljava/util/function/Function;Lnet/minecraft/network/codec/PacketCodec;Ljava/util/function/Function;Lnet/minecraft/network/codec/PacketCodec;Ljava/util/function/Function;Lcom/mojang/datafixers/util/Function3;)Lnet/minecraft/network/codec/PacketCodec;"
+            )
+        )
+        private static PacketCodec<RegistryByteBuf, ToolComponent.Rule> createPacketCodecAddExtraFields(PacketCodec<RegistryByteBuf, ToolComponent.Rule> original) {
+            return PacketCodec.tuple(
+                original, Function.identity(),
+                ToolComponentRuleExtraFields.PACKET_CODEC, rule -> ((RuleExtender)(Object) rule).extraFields,
+                (rule, extraFields) -> {
+                    ((RuleExtender)(Object) rule).extraFields = extraFields;
+                    return rule;
+                }
+            );
+        }
+
+        @Override
+        public boolean itematic$matches(ItemStack stack, BlockState state) {
+            if (this.blocks != null && !state.isIn(this.blocks)) {
+                return false;
+            }
+            return this.extraFields.item()
+                .map(item -> item.test(stack))
+                .orElse(true);
+        }
+
+        @Unique
+        @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
+        private static ToolComponent.Rule create(Optional<RegistryEntryList<Block>> blocks, Optional<Float> speed, Optional<Boolean> correctForDrops) {
+            return new ToolComponent.Rule(blocks.orElse(null), speed, correctForDrops);
+        }
+    }
+}

--- a/src/main/java/net/errorcraft/itematic/mixin/item/ItemExtender.java
+++ b/src/main/java/net/errorcraft/itematic/mixin/item/ItemExtender.java
@@ -25,6 +25,7 @@ import net.minecraft.component.ComponentMap;
 import net.minecraft.component.DataComponentType;
 import net.minecraft.component.DataComponentTypes;
 import net.minecraft.component.type.AttributeModifiersComponent;
+import net.minecraft.component.type.ToolComponent;
 import net.minecraft.component.type.WrittenBookContentComponent;
 import net.minecraft.enchantment.Enchantment;
 import net.minecraft.entity.Entity;
@@ -366,6 +367,28 @@ public abstract class ItemExtender implements ItemAccess, FabricItem {
                 c.use(miner, state, world, pos);
                 info.setReturnValue(false);
             });
+    }
+
+    @Redirect(
+        method = "getMiningSpeed",
+        at = @At(
+            value = "INVOKE",
+            target = "Lnet/minecraft/component/type/ToolComponent;getSpeed(Lnet/minecraft/block/BlockState;)F"
+        )
+    )
+    private float getSpeedPassItemStack(ToolComponent instance, BlockState state, ItemStack stack) {
+        return instance.itematic$getSpeed(stack, state);
+    }
+
+    @Redirect(
+        method = "isCorrectForDrops",
+        at = @At(
+            value = "INVOKE",
+            target = "Lnet/minecraft/component/type/ToolComponent;isCorrectForDrops(Lnet/minecraft/block/BlockState;)Z"
+        )
+    )
+    private boolean isCorrectForDropsPassItemStack(ToolComponent instance, BlockState state, ItemStack stack) {
+        return instance.itematic$isCorrectForDrops(stack, state);
     }
 
     /**

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -161,6 +161,12 @@
       ],
       "net/minecraft/class_9278": [
         "net/errorcraft/itematic/access/component/type/ChargedProjectilesComponentAccess"
+      ],
+      "net/minecraft/class_9424": [
+        "net/errorcraft/itematic/access/component/type/ToolComponentAccess"
+      ],
+      "net/minecraft/class_9424\u0024class_9425": [
+        "net/errorcraft/itematic/access/component/type/ToolComponentRuleAccess"
       ]
     }
   },

--- a/src/main/resources/itematic.mixins.json
+++ b/src/main/resources/itematic.mixins.json
@@ -87,6 +87,8 @@
     "component.type.BundleContentsComponentExtender$BuilderExtender",
     "component.type.ChargedProjectilesComponentExtender",
     "component.type.DyedColorComponentExtender",
+    "component.type.ToolComponentExtender",
+    "component.type.ToolComponentExtender$RuleExtender",
     "enchantment.EnchantmentExtender",
     "enchantment.EnchantmentHelperExtender",
     "entity.BucketableExtender",


### PR DESCRIPTION
- Introduced an item predicate to tool rules to check the item stack used to mine alongside the block that is being mined.
- Made the `blocks` field in a tool rule optional.
- The speed specified in a rule may now be 0 instead of being strictly positive.

Example that sets the mining speed to 0 when the durability is 1:
```json
{
  "minecraft:tool": {
    "rules": [
      {
        "item": {
          "predicates": {
            "minecraft:damage": {
              "durability": 1
            }
          }
        },
        "speed": 0.0
      },
      {
        "blocks": "#minecraft:incorrect_for_iron_tool",
        "correct_for_drops": false
      },
      {
        "blocks": "#minecraft:mineable/pickaxe",
        "correct_for_drops": true,
        "speed": 6.0
      }
    ]
  }
}
```

- This can be used in combination with the `preserve_item` field from the `minecraft:damageable` behaviour component to prevent the item from breaking and from being used as a tool altogether.