### PR TITLE
Expand the item holder behaviour

### DIFF
--- a/src/client/java/net/errorcraft/itematic/access/client/gui/tooltip/BundleTooltipComponentAccess.java
+++ b/src/client/java/net/errorcraft/itematic/access/client/gui/tooltip/BundleTooltipComponentAccess.java
@@ -1,5 +1,7 @@
 package net.errorcraft.itematic.access.client.gui.tooltip;
 
+import org.apache.commons.lang3.math.Fraction;
+
 public interface BundleTooltipComponentAccess {
-    void itematic$setCapacity(int capacity);
+    void itematic$setCapacity(Fraction capacity);
 }

--- a/src/client/java/net/errorcraft/itematic/mixin/client/gui/tooltip/BundleTooltipComponentExtender.java
+++ b/src/client/java/net/errorcraft/itematic/mixin/client/gui/tooltip/BundleTooltipComponentExtender.java
@@ -2,8 +2,8 @@ package net.errorcraft.itematic.mixin.client.gui.tooltip;
 
 import net.errorcraft.itematic.access.client.gui.tooltip.BundleTooltipComponentAccess;
 import net.minecraft.client.gui.tooltip.BundleTooltipComponent;
-import net.minecraft.item.Item;
 import org.apache.commons.lang3.math.Fraction;
+import org.objectweb.asm.Opcodes;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
@@ -19,6 +19,7 @@ public class BundleTooltipComponentExtender implements BundleTooltipComponentAcc
         at = @At(
             value = "FIELD",
             target = "Lorg/apache/commons/lang3/math/Fraction;ONE:Lorg/apache/commons/lang3/math/Fraction;",
+            opcode = Opcodes.GETSTATIC,
             remap = false
         )
     )
@@ -27,7 +28,7 @@ public class BundleTooltipComponentExtender implements BundleTooltipComponentAcc
     }
 
     @Override
-    public void itematic$setCapacity(int capacity) {
-        this.capacity = Fraction.getFraction(capacity, Item.DEFAULT_MAX_COUNT);
+    public void itematic$setCapacity(Fraction capacity) {
+        this.capacity = capacity;
     }
 }

--- a/src/datagen/java/net/errorcraft/itematic/data/server/tag/ItemTagProvider.java
+++ b/src/datagen/java/net/errorcraft/itematic/data/server/tag/ItemTagProvider.java
@@ -1265,6 +1265,8 @@ public class ItemTagProvider extends FabricTagProvider<Item> {
             .add(ItemKeys.SPIRE_ARMOR_TRIM_SMITHING_TEMPLATE);
         this.getOrCreateTagBuilder(ItematicItemTags.SPAWNERS)
             .add(ItemKeys.SPAWNER);
+        this.getOrCreateTagBuilder(ItematicItemTags.BANNED_BUNDLE_ITEMS)
+            .addTag(ItematicItemTags.SHULKER_BOXES);
         this.getOrCreateTagBuilder(ItematicItemTags.SHULKER_BOXES)
             .add(ItemKeys.SHULKER_BOX)
             .add(ItemKeys.BLACK_SHULKER_BOX)

--- a/src/gametest/java/net/errorcraft/itematic/gametest/Assert.java
+++ b/src/gametest/java/net/errorcraft/itematic/gametest/Assert.java
@@ -53,6 +53,12 @@ public class Assert {
         }
     }
 
+    public static void itemStackIsNotEmpty(ItemStack value) {
+        if (value.isEmpty()) {
+            throw new GameTestException("Expected item stack not to be empty");
+        }
+    }
+
     public static <T> void itemStackHasComponent(ItemStack value, DataComponentType<T> type) {
         if (value.get(type) == null) {
             throw new GameTestException("Expected item stack to contain the " + type + " component");

--- a/src/gametest/java/net/errorcraft/itematic/gametest/item/BundleTestSuite.java
+++ b/src/gametest/java/net/errorcraft/itematic/gametest/item/BundleTestSuite.java
@@ -1,0 +1,75 @@
+package net.errorcraft.itematic.gametest.item;
+
+import net.errorcraft.itematic.gametest.Assert;
+import net.errorcraft.itematic.item.ItemKeys;
+import net.errorcraft.itematic.mixin.component.type.BundleContentsComponentAccessor;
+import net.fabricmc.fabric.api.gametest.v1.FabricGameTest;
+import net.minecraft.component.DataComponentTypes;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.entity.player.PlayerInventory;
+import net.minecraft.item.ItemStack;
+import net.minecraft.screen.slot.Slot;
+import net.minecraft.server.world.ServerWorld;
+import net.minecraft.test.GameTest;
+import net.minecraft.test.TestContext;
+import net.minecraft.util.ClickType;
+import net.minecraft.world.GameMode;
+
+public class BundleTestSuite {
+    private static final int SLOT_INDEX = 0;
+
+    @GameTest(templateName = FabricGameTest.EMPTY_STRUCTURE)
+    public void addingNormalItemToBundleAddsIt(TestContext context) {
+        ServerWorld world = context.getWorld();
+        ItemStack bundleStack = world.itematic$createStack(ItemKeys.BUNDLE);
+        ItemStack addedStack = world.itematic$createStack(ItemKeys.STICK);
+        PlayerEntity player = context.createMockPlayer(GameMode.SURVIVAL);
+        PlayerInventory inventory = player.getInventory();
+        inventory.insertStack(SLOT_INDEX, addedStack);
+        Slot slot = new Slot(inventory, SLOT_INDEX, 0, 0);
+        context.addInstantFinalTask(() -> {
+            context.assertTrue(bundleStack.onStackClicked(slot, ClickType.RIGHT, player), "Expected right-clicking with Bundle to be successful");
+            Assert.itemStackIsEmpty(slot.getStack());
+            Assert.itemStackHasComponent(bundleStack, DataComponentTypes.BUNDLE_CONTENTS, bundleContents -> {
+                Assert.itemStackIsOf(bundleContents.get(0), ItemKeys.STICK);
+            });
+        });
+    }
+
+    @GameTest(templateName = FabricGameTest.EMPTY_STRUCTURE)
+    public void addingShulkerBoxToBundleRejectsIt(TestContext context) {
+        ServerWorld world = context.getWorld();
+        ItemStack bundleStack = world.itematic$createStack(ItemKeys.BUNDLE);
+        ItemStack addedStack = world.itematic$createStack(ItemKeys.SHULKER_BOX);
+        PlayerEntity player = context.createMockPlayer(GameMode.SURVIVAL);
+        PlayerInventory inventory = player.getInventory();
+        inventory.insertStack(SLOT_INDEX, addedStack);
+        Slot slot = new Slot(inventory, SLOT_INDEX, 0, 0);
+        context.addInstantFinalTask(() -> {
+            context.assertTrue(bundleStack.onStackClicked(slot, ClickType.RIGHT, player), "Expected right-clicking with Bundle to be successful");
+            Assert.itemStackIsNotEmpty(slot.getStack());
+            Assert.itemStackHasComponent(bundleStack, DataComponentTypes.BUNDLE_CONTENTS, bundleContents -> {
+                context.assertTrue(bundleContents.isEmpty(), "Expected Bundle to be empty");
+            });
+        });
+    }
+
+    @GameTest(templateName = FabricGameTest.EMPTY_STRUCTURE)
+    public void addingBundleToBundleAddsItWithPenalty(TestContext context) {
+        ServerWorld world = context.getWorld();
+        ItemStack bundleStack = world.itematic$createStack(ItemKeys.BUNDLE);
+        ItemStack addedStack = world.itematic$createStack(ItemKeys.BUNDLE);
+        PlayerEntity player = context.createMockPlayer(GameMode.SURVIVAL);
+        PlayerInventory inventory = player.getInventory();
+        inventory.insertStack(SLOT_INDEX, addedStack);
+        Slot slot = new Slot(inventory, SLOT_INDEX, 0, 0);
+        context.addInstantFinalTask(() -> {
+            context.assertTrue(bundleStack.onStackClicked(slot, ClickType.RIGHT, player), "Expected right-clicking with Bundle to be successful");
+            Assert.itemStackIsEmpty(slot.getStack());
+            Assert.itemStackHasComponent(bundleStack, DataComponentTypes.BUNDLE_CONTENTS, bundleContents -> {
+                Assert.itemStackIsOf(bundleContents.get(0), ItemKeys.BUNDLE);
+                context.assertEquals(bundleContents.getOccupancy(), BundleContentsComponentAccessor.nestedBundleOccupancy(), "occupancy");
+            });
+        });
+    }
+}

--- a/src/gametest/java/net/errorcraft/itematic/gametest/item/component/ItemHolderItemComponentTestSuite.java
+++ b/src/gametest/java/net/errorcraft/itematic/gametest/item/component/ItemHolderItemComponentTestSuite.java
@@ -1,8 +1,10 @@
 package net.errorcraft.itematic.gametest.item.component;
 
 import net.errorcraft.itematic.gametest.Assert;
+import net.errorcraft.itematic.gametest.TestUtil;
 import net.errorcraft.itematic.inventory.StackReferenceUtil;
 import net.errorcraft.itematic.item.ItemKeys;
+import net.errorcraft.itematic.item.component.ItemComponentTypes;
 import net.fabricmc.fabric.api.gametest.v1.FabricGameTest;
 import net.minecraft.component.DataComponentTypes;
 import net.minecraft.component.type.BundleContentsComponent;
@@ -17,7 +19,7 @@ import net.minecraft.test.TestContext;
 import net.minecraft.util.ClickType;
 import net.minecraft.world.GameMode;
 
-import java.util.List;
+import java.util.Objects;
 
 public class ItemHolderItemComponentTestSuite {
     private static final int SLOT = 0;
@@ -48,7 +50,7 @@ public class ItemHolderItemComponentTestSuite {
         PlayerInventory inventory = player.getInventory();
         ItemStack stack = world.itematic$createStack(ItemKeys.BUNDLE);
         ItemStack stackToRemove = world.itematic$createStack(ItemKeys.STICK);
-        stack.set(DataComponentTypes.BUNDLE_CONTENTS, new BundleContentsComponent(List.of(stackToRemove)));
+        addToBundleContentsComponent(stack, stackToRemove);
         Slot slot = new Slot(inventory, SLOT, 0, 0);
         world.spawnEntity(player);
         boolean success = stack.onStackClicked(slot, ClickType.RIGHT, player);
@@ -89,7 +91,7 @@ public class ItemHolderItemComponentTestSuite {
         PlayerInventory inventory = player.getInventory();
         ItemStack stack = world.itematic$createStack(ItemKeys.BUNDLE);
         ItemStack stackToRemove = world.itematic$createStack(ItemKeys.STICK);
-        stack.set(DataComponentTypes.BUNDLE_CONTENTS, new BundleContentsComponent(List.of(stackToRemove)));
+        addToBundleContentsComponent(stack, stackToRemove);
         inventory.insertStack(SLOT, stack);
         stack = inventory.getStack(SLOT);
         StackReference cursorStack = StackReferenceUtil.of(ItemStack.EMPTY);
@@ -103,5 +105,13 @@ public class ItemHolderItemComponentTestSuite {
                 component -> context.assertTrue(component.isEmpty(), "Expected bundle to be empty")
             );
         });
+    }
+
+    private static void addToBundleContentsComponent(ItemStack origin, ItemStack stackToAdd) {
+        BundleContentsComponent.Builder builder = Objects.requireNonNull(
+            TestUtil.getItemComponent(origin, ItemComponentTypes.ITEM_HOLDER).createBuilder(origin)
+        );
+        builder.add(stackToAdd);
+        origin.set(DataComponentTypes.BUNDLE_CONTENTS, builder.build());
     }
 }

--- a/src/gametest/resources/fabric.mod.json
+++ b/src/gametest/resources/fabric.mod.json
@@ -24,6 +24,7 @@
       "net.errorcraft.itematic.gametest.entity.passive.SheepEntityTestSuite",
       "net.errorcraft.itematic.gametest.entity.passive.SnifferEntityTestSuite",
       "net.errorcraft.itematic.gametest.entity.passive.WolfEntityTestSuite",
+      "net.errorcraft.itematic.gametest.item.BundleTestSuite",
       "net.errorcraft.itematic.gametest.item.BrushTestSuite",
       "net.errorcraft.itematic.gametest.item.FishingRodTestSuite",
       "net.errorcraft.itematic.gametest.item.FlowerPotItemTestSuite",

--- a/src/main/generated/data/minecraft/item/bundle.json
+++ b/src/main/generated/data/minecraft/item/bundle.json
@@ -23,7 +23,7 @@
             ]
           },
           "fraction": {
-            "denominator": 4,
+            "denominator": 16,
             "numerator": 1
           }
         },

--- a/src/main/generated/data/minecraft/item/bundle.json
+++ b/src/main/generated/data/minecraft/item/bundle.json
@@ -4,7 +4,10 @@
   },
   "components": {
     "minecraft:item_holder": {
-      "capacity": 64,
+      "capacity": {
+        "denominator": 1,
+        "numerator": 1
+      },
       "empty_sound": "minecraft:item.bundle.drop_contents",
       "insert_item_sound": "minecraft:item.bundle.insert",
       "remove_item_sound": "minecraft:item.bundle.remove_one",

--- a/src/main/generated/data/minecraft/item/bundle.json
+++ b/src/main/generated/data/minecraft/item/bundle.json
@@ -7,7 +7,39 @@
       "capacity": 64,
       "empty_sound": "minecraft:item.bundle.drop_contents",
       "insert_item_sound": "minecraft:item.bundle.insert",
-      "remove_item_sound": "minecraft:item.bundle.remove_one"
+      "remove_item_sound": "minecraft:item.bundle.remove_one",
+      "rules": [
+        {
+          "type": "minecraft:reject",
+          "condition": {
+            "items": "#minecraft:banned_bundle_items"
+          }
+        },
+        {
+          "type": "minecraft:fraction_with_occupancy_held_items",
+          "condition": {
+            "behavior": [
+              "minecraft:item_holder"
+            ]
+          },
+          "fraction": {
+            "denominator": 4,
+            "numerator": 1
+          }
+        },
+        {
+          "type": "minecraft:fraction",
+          "condition": {
+            "data_components": [
+              "minecraft:bees"
+            ]
+          },
+          "fraction": {
+            "denominator": 1,
+            "numerator": 1
+          }
+        }
+      ]
     },
     "minecraft:stackable": 1
   }

--- a/src/main/generated/data/minecraft/tags/items/banned_bundle_items.json
+++ b/src/main/generated/data/minecraft/tags/items/banned_bundle_items.json
@@ -1,0 +1,5 @@
+{
+  "values": [
+    "#minecraft:shulker_boxes"
+  ]
+}

--- a/src/main/java/net/errorcraft/itematic/Itematic.java
+++ b/src/main/java/net/errorcraft/itematic/Itematic.java
@@ -4,6 +4,7 @@ import net.errorcraft.itematic.component.ItematicDataComponentTypes;
 import net.errorcraft.itematic.item.color.ItemColorTypes;
 import net.errorcraft.itematic.item.component.ItemComponentTypes;
 import net.errorcraft.itematic.item.event.ItemEvents;
+import net.errorcraft.itematic.item.holder.rule.ItemHolderRuleTypes;
 import net.errorcraft.itematic.item.model.override.ModelOverrides;
 import net.errorcraft.itematic.item.placement.block.picker.BlockPickerTypes;
 import net.errorcraft.itematic.item.pointer.Pointers;
@@ -39,5 +40,6 @@ public class Itematic implements ModInitializer {
         TradeModifierTypes.init();
         ItematicDataComponentTypes.init();
         IntegerProviderTypes.init();
+        ItemHolderRuleTypes.init();
     }
 }

--- a/src/main/java/net/errorcraft/itematic/access/client/item/BundleTooltipDataAccess.java
+++ b/src/main/java/net/errorcraft/itematic/access/client/item/BundleTooltipDataAccess.java
@@ -1,8 +1,10 @@
 package net.errorcraft.itematic.access.client.item;
 
+import org.apache.commons.lang3.math.Fraction;
+
 public interface BundleTooltipDataAccess {
-    default int itematic$capacity() {
-        return 0;
+    default Fraction itematic$capacity() {
+        return null;
     }
-    default void itematic$setCapacity(int capacity) {}
+    default void itematic$setCapacity(Fraction capacity) {}
 }

--- a/src/main/java/net/errorcraft/itematic/access/component/type/BundleContentsComponentAccess.java
+++ b/src/main/java/net/errorcraft/itematic/access/component/type/BundleContentsComponentAccess.java
@@ -1,0 +1,17 @@
+package net.errorcraft.itematic.access.component.type;
+
+import net.errorcraft.itematic.component.type.BundleContentsComponentExtraFields;
+import net.minecraft.item.ItemStack;
+
+import java.util.List;
+
+public interface BundleContentsComponentAccess {
+    default List<ItemStack> itematic$stacks() {
+        return null;
+    }
+    default BundleContentsComponentExtraFields itematic$extraFields() {
+        return null;
+    }
+    default void itematic$setExtraFields(BundleContentsComponentExtraFields extraFields) {}
+    default void itematic$calculateOccupancy() {}
+}

--- a/src/main/java/net/errorcraft/itematic/access/component/type/BundleContentsComponentBuilderAccess.java
+++ b/src/main/java/net/errorcraft/itematic/access/component/type/BundleContentsComponentBuilderAccess.java
@@ -1,5 +1,7 @@
 package net.errorcraft.itematic.access.component.type;
 
+import org.apache.commons.lang3.math.Fraction;
+
 public interface BundleContentsComponentBuilderAccess {
-    default void itematic$setCapacity(int capacity) {}
+    default void itematic$setCapacity(Fraction capacity) {}
 }

--- a/src/main/java/net/errorcraft/itematic/access/component/type/BundleContentsComponentBuilderAccess.java
+++ b/src/main/java/net/errorcraft/itematic/access/component/type/BundleContentsComponentBuilderAccess.java
@@ -1,5 +1,8 @@
 package net.errorcraft.itematic.access.component.type;
 
+import net.errorcraft.itematic.item.holder.rule.ItemHolderRules;
+
 public interface BundleContentsComponentBuilderAccess {
     default void itematic$setCapacity(int capacity) {}
+    default void itematic$setRules(ItemHolderRules rules) {}
 }

--- a/src/main/java/net/errorcraft/itematic/access/component/type/BundleContentsComponentBuilderAccess.java
+++ b/src/main/java/net/errorcraft/itematic/access/component/type/BundleContentsComponentBuilderAccess.java
@@ -1,8 +1,5 @@
 package net.errorcraft.itematic.access.component.type;
 
-import net.errorcraft.itematic.item.holder.rule.ItemHolderRules;
-
 public interface BundleContentsComponentBuilderAccess {
     default void itematic$setCapacity(int capacity) {}
-    default void itematic$setRules(ItemHolderRules rules) {}
 }

--- a/src/main/java/net/errorcraft/itematic/access/predicate/item/ItemPredicateAccess.java
+++ b/src/main/java/net/errorcraft/itematic/access/predicate/item/ItemPredicateAccess.java
@@ -1,0 +1,8 @@
+package net.errorcraft.itematic.access.predicate.item;
+
+import net.errorcraft.itematic.predicate.item.ItemPredicateExtraFields;
+
+public interface ItemPredicateAccess {
+    ItemPredicateExtraFields itematic$extraFields();
+    void itematic$setExtraFields(ItemPredicateExtraFields extraFields);
+}

--- a/src/main/java/net/errorcraft/itematic/access/predicate/item/ItemPredicateBuilderAccess.java
+++ b/src/main/java/net/errorcraft/itematic/access/predicate/item/ItemPredicateBuilderAccess.java
@@ -1,0 +1,19 @@
+package net.errorcraft.itematic.access.predicate.item;
+
+import net.errorcraft.itematic.item.component.ItemComponentType;
+import net.minecraft.component.DataComponentType;
+import net.minecraft.item.Item;
+import net.minecraft.predicate.item.ItemPredicate;
+import net.minecraft.registry.entry.RegistryEntryList;
+
+public interface ItemPredicateBuilderAccess {
+    default ItemPredicate.Builder itematic$items(RegistryEntryList<Item> items) {
+        return null;
+    }
+    default ItemPredicate.Builder itematic$behavior(ItemComponentType<?>... behavior) {
+        return null;
+    }
+    default ItemPredicate.Builder itematic$dataComponents(DataComponentType<?>... dataComponents) {
+        return null;
+    }
+}

--- a/src/main/java/net/errorcraft/itematic/component/ItematicDataComponentTypes.java
+++ b/src/main/java/net/errorcraft/itematic/component/ItematicDataComponentTypes.java
@@ -4,12 +4,15 @@ import net.errorcraft.itematic.component.type.ImmuneToDamageComponent;
 import net.errorcraft.itematic.component.type.ItemListDataComponent;
 import net.errorcraft.itematic.component.type.UseDurationDataComponent;
 import net.errorcraft.itematic.component.type.WeaponAttackDamageDataComponent;
+import net.errorcraft.itematic.item.component.components.ItemHolderItemComponent;
 import net.errorcraft.itematic.mixin.component.DataComponentTypesAccessor;
+import net.errorcraft.itematic.network.codec.PacketCodecUtil;
 import net.errorcraft.itematic.serialization.ItematicCodecs;
 import net.errorcraft.itematic.util.UseActionUtil;
 import net.minecraft.component.DataComponentType;
 import net.minecraft.network.codec.PacketCodecs;
 import net.minecraft.util.UseAction;
+import org.apache.commons.lang3.math.Fraction;
 
 public class ItematicDataComponentTypes {
     public static final DataComponentType<ImmuneToDamageComponent> IMMUNE_TO_DAMAGE = DataComponentTypesAccessor.register("immune_to_damage", builder -> builder.codec(ImmuneToDamageComponent.CODEC).packetCodec(ImmuneToDamageComponent.PACKET_CODEC));
@@ -19,6 +22,7 @@ public class ItematicDataComponentTypes {
     public static final DataComponentType<ItemListDataComponent> SHOOTER_HELD_AMMUNITION = DataComponentTypesAccessor.register("shooter_held_ammunition", builder -> builder.codec(ItemListDataComponent.CODEC).packetCodec(ItemListDataComponent.PACKET_CODEC));
     public static final DataComponentType<Double> ATTACK_SPEED_MULTIPLIER = DataComponentTypesAccessor.register("attack_speed_multiplier", builder -> builder.codec(ItematicCodecs.NON_NEGATIVE_DOUBLE).packetCodec(PacketCodecs.DOUBLE));
     public static final DataComponentType<WeaponAttackDamageDataComponent> WEAPON_ATTACK_DAMAGE = DataComponentTypesAccessor.register("weapon_attack_damage", builder -> builder.codec(WeaponAttackDamageDataComponent.CODEC).packetCodec(WeaponAttackDamageDataComponent.PACKET_CODEC));
+    public static final DataComponentType<Fraction> ITEM_HOLDER_CAPACITY = DataComponentTypesAccessor.register("item_holder_capacity", builder -> builder.codec(ItemHolderItemComponent.CAPACITY_CODEC).packetCodec(PacketCodecUtil.FRACTION));
 
     public static void init() {}
 }

--- a/src/main/java/net/errorcraft/itematic/component/ItematicDataComponentTypes.java
+++ b/src/main/java/net/errorcraft/itematic/component/ItematicDataComponentTypes.java
@@ -1,7 +1,9 @@
 package net.errorcraft.itematic.component;
 
-import net.errorcraft.itematic.component.type.*;
-import net.errorcraft.itematic.item.holder.rule.ItemHolderRules;
+import net.errorcraft.itematic.component.type.ImmuneToDamageComponent;
+import net.errorcraft.itematic.component.type.ItemListDataComponent;
+import net.errorcraft.itematic.component.type.UseDurationDataComponent;
+import net.errorcraft.itematic.component.type.WeaponAttackDamageDataComponent;
 import net.errorcraft.itematic.mixin.component.DataComponentTypesAccessor;
 import net.errorcraft.itematic.serialization.ItematicCodecs;
 import net.errorcraft.itematic.util.UseActionUtil;
@@ -17,7 +19,6 @@ public class ItematicDataComponentTypes {
     public static final DataComponentType<ItemListDataComponent> SHOOTER_HELD_AMMUNITION = DataComponentTypesAccessor.register("shooter_held_ammunition", builder -> builder.codec(ItemListDataComponent.CODEC).packetCodec(ItemListDataComponent.PACKET_CODEC));
     public static final DataComponentType<Double> ATTACK_SPEED_MULTIPLIER = DataComponentTypesAccessor.register("attack_speed_multiplier", builder -> builder.codec(ItematicCodecs.NON_NEGATIVE_DOUBLE).packetCodec(PacketCodecs.DOUBLE));
     public static final DataComponentType<WeaponAttackDamageDataComponent> WEAPON_ATTACK_DAMAGE = DataComponentTypesAccessor.register("weapon_attack_damage", builder -> builder.codec(WeaponAttackDamageDataComponent.CODEC).packetCodec(WeaponAttackDamageDataComponent.PACKET_CODEC));
-    public static final DataComponentType<ItemHolderRules> ITEM_HOLDER_RULES = DataComponentTypesAccessor.register("item_holder_rules", builder -> builder.codec(ItemHolderRules.CODEC).packetCodec(ItemHolderRules.PACKET_CODEC));
 
     public static void init() {}
 }

--- a/src/main/java/net/errorcraft/itematic/component/ItematicDataComponentTypes.java
+++ b/src/main/java/net/errorcraft/itematic/component/ItematicDataComponentTypes.java
@@ -1,9 +1,7 @@
 package net.errorcraft.itematic.component;
 
-import net.errorcraft.itematic.component.type.ImmuneToDamageComponent;
-import net.errorcraft.itematic.component.type.ItemListDataComponent;
-import net.errorcraft.itematic.component.type.UseDurationDataComponent;
-import net.errorcraft.itematic.component.type.WeaponAttackDamageDataComponent;
+import net.errorcraft.itematic.component.type.*;
+import net.errorcraft.itematic.item.holder.rule.ItemHolderRules;
 import net.errorcraft.itematic.mixin.component.DataComponentTypesAccessor;
 import net.errorcraft.itematic.serialization.ItematicCodecs;
 import net.errorcraft.itematic.util.UseActionUtil;
@@ -19,6 +17,7 @@ public class ItematicDataComponentTypes {
     public static final DataComponentType<ItemListDataComponent> SHOOTER_HELD_AMMUNITION = DataComponentTypesAccessor.register("shooter_held_ammunition", builder -> builder.codec(ItemListDataComponent.CODEC).packetCodec(ItemListDataComponent.PACKET_CODEC));
     public static final DataComponentType<Double> ATTACK_SPEED_MULTIPLIER = DataComponentTypesAccessor.register("attack_speed_multiplier", builder -> builder.codec(ItematicCodecs.NON_NEGATIVE_DOUBLE).packetCodec(PacketCodecs.DOUBLE));
     public static final DataComponentType<WeaponAttackDamageDataComponent> WEAPON_ATTACK_DAMAGE = DataComponentTypesAccessor.register("weapon_attack_damage", builder -> builder.codec(WeaponAttackDamageDataComponent.CODEC).packetCodec(WeaponAttackDamageDataComponent.PACKET_CODEC));
+    public static final DataComponentType<ItemHolderRules> ITEM_HOLDER_RULES = DataComponentTypesAccessor.register("item_holder_rules", builder -> builder.codec(ItemHolderRules.CODEC).packetCodec(ItemHolderRules.PACKET_CODEC));
 
     public static void init() {}
 }

--- a/src/main/java/net/errorcraft/itematic/component/type/BundleContentsComponentExtraFields.java
+++ b/src/main/java/net/errorcraft/itematic/component/type/BundleContentsComponentExtraFields.java
@@ -1,0 +1,14 @@
+package net.errorcraft.itematic.component.type;
+
+import com.mojang.serialization.Codec;
+import net.errorcraft.itematic.item.holder.rule.ItemHolderRules;
+import net.minecraft.network.RegistryByteBuf;
+import net.minecraft.network.codec.PacketCodec;
+
+import java.util.List;
+
+public record BundleContentsComponentExtraFields(ItemHolderRules rules) {
+    public static final BundleContentsComponentExtraFields DEFAULT = new BundleContentsComponentExtraFields(new ItemHolderRules(List.of()));
+    public static final Codec<BundleContentsComponentExtraFields> CODEC = ItemHolderRules.CODEC.xmap(BundleContentsComponentExtraFields::new, BundleContentsComponentExtraFields::rules);
+    public static final PacketCodec<RegistryByteBuf, BundleContentsComponentExtraFields> PACKET_CODEC = ItemHolderRules.PACKET_CODEC.xmap(BundleContentsComponentExtraFields::new, BundleContentsComponentExtraFields::rules);
+}

--- a/src/main/java/net/errorcraft/itematic/component/type/BundleContentsComponentUtil.java
+++ b/src/main/java/net/errorcraft/itematic/component/type/BundleContentsComponentUtil.java
@@ -1,0 +1,22 @@
+package net.errorcraft.itematic.component.type;
+
+import net.errorcraft.itematic.item.holder.rule.ItemHolderRules;
+import net.minecraft.component.type.BundleContentsComponent;
+import net.minecraft.item.ItemStack;
+
+import java.util.List;
+
+public class BundleContentsComponentUtil {
+    private BundleContentsComponentUtil() {}
+
+    public static BundleContentsComponent create(BundleContentsComponentExtraFields extraFields, List<ItemStack> stacks) {
+        BundleContentsComponent component = new BundleContentsComponent(stacks);
+        component.itematic$setExtraFields(extraFields);
+        component.itematic$calculateOccupancy();
+        return component;
+    }
+
+    public static BundleContentsComponent create(ItemHolderRules rules) {
+        return create(new BundleContentsComponentExtraFields(rules), List.of());
+    }
+}

--- a/src/main/java/net/errorcraft/itematic/item/ItemUtil.java
+++ b/src/main/java/net/errorcraft/itematic/item/ItemUtil.java
@@ -5,7 +5,6 @@ import com.mojang.serialization.codecs.RecordCodecBuilder;
 import net.errorcraft.itematic.block.BlockKeys;
 import net.errorcraft.itematic.block.ComposterBlockUtil;
 import net.errorcraft.itematic.block.entity.FurnaceBlockEntityUtil;
-import net.errorcraft.itematic.item.holder.rule.ItemHolderRules;
 import net.errorcraft.itematic.enchantment.EnchantmentTags;
 import net.errorcraft.itematic.entity.EntityTypeKeys;
 import net.errorcraft.itematic.entity.ItematicEntityTypeTags;
@@ -22,6 +21,7 @@ import net.errorcraft.itematic.item.dispense.behavior.DispenseBehavior;
 import net.errorcraft.itematic.item.dispense.behavior.DispenseBehaviors;
 import net.errorcraft.itematic.item.event.ItemEventMap;
 import net.errorcraft.itematic.item.event.ItemEvents;
+import net.errorcraft.itematic.item.holder.rule.ItemHolderRules;
 import net.errorcraft.itematic.item.holder.rule.rules.FractionItemHolderRule;
 import net.errorcraft.itematic.item.holder.rule.rules.FractionWithOccupancyHeldItemsItemHolderRule;
 import net.errorcraft.itematic.item.holder.rule.rules.RejectItemHolderRule;
@@ -31,6 +31,7 @@ import net.errorcraft.itematic.item.smithing.template.SmithingTemplate;
 import net.errorcraft.itematic.item.smithing.template.SmithingTemplates;
 import net.errorcraft.itematic.loot.predicate.SideCheckPredicate;
 import net.errorcraft.itematic.mixin.block.DecoratedPotPatternsAccessor;
+import net.errorcraft.itematic.mixin.component.type.BundleContentsComponentAccessor;
 import net.errorcraft.itematic.mixin.item.*;
 import net.errorcraft.itematic.potion.PotionKeys;
 import net.errorcraft.itematic.registry.ItematicRegistryKeys;
@@ -85,6 +86,7 @@ import net.minecraft.util.math.Direction;
 import net.minecraft.world.biome.Biome;
 import net.minecraft.world.biome.BiomeKeys;
 import net.minecraft.world.event.GameEvent;
+import org.apache.commons.lang3.math.Fraction;
 
 import java.util.List;
 
@@ -9741,10 +9743,10 @@ public class ItemUtil {
                             .rule(RejectItemHolderRule.INSTANCE, ItemPredicate.Builder.create()
                                 .itematic$items(this.items.getOrThrow(ItematicItemTags.BANNED_BUNDLE_ITEMS))
                                 .build())
-                            .rule(FractionWithOccupancyHeldItemsItemHolderRule.of(1, 4), ItemPredicate.Builder.create()
+                            .rule(FractionWithOccupancyHeldItemsItemHolderRule.of(BundleContentsComponentAccessor.nestedBundleOccupancy()), ItemPredicate.Builder.create()
                                 .itematic$behavior(ItemComponentTypes.ITEM_HOLDER)
                                 .build())
-                            .rule(FractionItemHolderRule.of(1, 1), ItemPredicate.Builder.create()
+                            .rule(FractionItemHolderRule.of(Fraction.ONE), ItemPredicate.Builder.create()
                                 .itematic$dataComponents(DataComponentTypes.BEES)
                                 .build())
                             .build(),

--- a/src/main/java/net/errorcraft/itematic/item/ItemUtil.java
+++ b/src/main/java/net/errorcraft/itematic/item/ItemUtil.java
@@ -5,6 +5,7 @@ import com.mojang.serialization.codecs.RecordCodecBuilder;
 import net.errorcraft.itematic.block.BlockKeys;
 import net.errorcraft.itematic.block.ComposterBlockUtil;
 import net.errorcraft.itematic.block.entity.FurnaceBlockEntityUtil;
+import net.errorcraft.itematic.item.holder.rule.ItemHolderRules;
 import net.errorcraft.itematic.enchantment.EnchantmentTags;
 import net.errorcraft.itematic.entity.EntityTypeKeys;
 import net.errorcraft.itematic.entity.ItematicEntityTypeTags;
@@ -15,11 +16,15 @@ import net.errorcraft.itematic.item.armor.ArmorMaterial;
 import net.errorcraft.itematic.item.armor.ArmorMaterialKeys;
 import net.errorcraft.itematic.item.color.colors.*;
 import net.errorcraft.itematic.item.component.ItemComponentSet;
+import net.errorcraft.itematic.item.component.ItemComponentTypes;
 import net.errorcraft.itematic.item.component.components.*;
 import net.errorcraft.itematic.item.dispense.behavior.DispenseBehavior;
 import net.errorcraft.itematic.item.dispense.behavior.DispenseBehaviors;
 import net.errorcraft.itematic.item.event.ItemEventMap;
 import net.errorcraft.itematic.item.event.ItemEvents;
+import net.errorcraft.itematic.item.holder.rule.rules.FractionItemHolderRule;
+import net.errorcraft.itematic.item.holder.rule.rules.FractionWithOccupancyHeldItemsItemHolderRule;
+import net.errorcraft.itematic.item.holder.rule.rules.RejectItemHolderRule;
 import net.errorcraft.itematic.item.pointer.Pointer;
 import net.errorcraft.itematic.item.pointer.PointerKeys;
 import net.errorcraft.itematic.item.smithing.template.SmithingTemplate;
@@ -9730,7 +9735,22 @@ public class ItemUtil {
                 ItemBase.Builder.forItem(ItemKeys.BUNDLE).build(),
                 ItemComponentSet.builder()
                     .with(StackableItemComponent.of(1))
-                    .with(ItemHolderItemComponent.of(Item.DEFAULT_MAX_COUNT, this.soundEvents.getOrThrow(SoundEventKeys.BUNDLE_INSERT), this.soundEvents.getOrThrow(SoundEventKeys.BUNDLE_REMOVE_ONE), this.soundEvents.getOrThrow(SoundEventKeys.BUNDLE_DROP_CONTENTS)))
+                    .with(ItemHolderItemComponent.of(
+                        Item.DEFAULT_MAX_COUNT,
+                        ItemHolderRules.builder()
+                            .rule(RejectItemHolderRule.INSTANCE, ItemPredicate.Builder.create()
+                                .itematic$items(this.items.getOrThrow(ItematicItemTags.BANNED_BUNDLE_ITEMS))
+                                .build())
+                            .rule(FractionWithOccupancyHeldItemsItemHolderRule.of(1, 4), ItemPredicate.Builder.create()
+                                .itematic$behavior(ItemComponentTypes.ITEM_HOLDER)
+                                .build())
+                            .rule(FractionItemHolderRule.of(1, 1), ItemPredicate.Builder.create()
+                                .itematic$dataComponents(DataComponentTypes.BEES)
+                                .build())
+                            .build(),
+                        this.soundEvents.getOrThrow(SoundEventKeys.BUNDLE_INSERT),
+                        this.soundEvents.getOrThrow(SoundEventKeys.BUNDLE_REMOVE_ONE),
+                        this.soundEvents.getOrThrow(SoundEventKeys.BUNDLE_DROP_CONTENTS)))
                     .build()
             ));
             this.registerable.register(ItemKeys.CLOCK, create(

--- a/src/main/java/net/errorcraft/itematic/item/ItemUtil.java
+++ b/src/main/java/net/errorcraft/itematic/item/ItemUtil.java
@@ -9738,7 +9738,7 @@ public class ItemUtil {
                 ItemComponentSet.builder()
                     .with(StackableItemComponent.of(1))
                     .with(ItemHolderItemComponent.of(
-                        Item.DEFAULT_MAX_COUNT,
+                        1,
                         ItemHolderRules.builder()
                             .rule(RejectItemHolderRule.INSTANCE, ItemPredicate.Builder.create()
                                 .itematic$items(this.items.getOrThrow(ItematicItemTags.BANNED_BUNDLE_ITEMS))

--- a/src/main/java/net/errorcraft/itematic/item/ItematicItemTags.java
+++ b/src/main/java/net/errorcraft/itematic/item/ItematicItemTags.java
@@ -153,6 +153,7 @@ public class ItematicItemTags {
     public static final TagKey<Item> SMITHING_TEMPLATES = of("item_group/smithing_templates");
     public static final TagKey<Item> SPAWNERS = of("item_group/spawners");
 
+    public static final TagKey<Item> BANNED_BUNDLE_ITEMS = of("banned_bundle_items");
     public static final TagKey<Item> SHULKER_BOXES = of("shulker_boxes");
 
     public static final TagKey<Item> PREVENTS_MINING_IN_CREATIVE = of("prevents_mining_in_creative");

--- a/src/main/java/net/errorcraft/itematic/item/component/components/ItemHolderItemComponent.java
+++ b/src/main/java/net/errorcraft/itematic/item/component/components/ItemHolderItemComponent.java
@@ -2,12 +2,12 @@ package net.errorcraft.itematic.item.component.components;
 
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
-import net.errorcraft.itematic.component.ItematicDataComponentTypes;
-import net.errorcraft.itematic.item.holder.rule.ItemHolderRules;
+import net.errorcraft.itematic.component.type.BundleContentsComponentUtil;
 import net.errorcraft.itematic.item.ItemStackConsumer;
 import net.errorcraft.itematic.item.component.ItemComponent;
 import net.errorcraft.itematic.item.component.ItemComponentType;
 import net.errorcraft.itematic.item.component.ItemComponentTypes;
+import net.errorcraft.itematic.item.holder.rule.ItemHolderRules;
 import net.errorcraft.itematic.mixin.item.BundleItemAccessor;
 import net.errorcraft.itematic.util.Util;
 import net.minecraft.client.item.BundleTooltipData;
@@ -117,8 +117,7 @@ public record ItemHolderItemComponent(int capacity, ItemHolderRules rules, Regis
 
     @Override
     public void addComponents(ComponentMap.Builder builder) {
-        builder.add(DataComponentTypes.BUNDLE_CONTENTS, BundleContentsComponent.DEFAULT);
-        builder.add(ItematicDataComponentTypes.ITEM_HOLDER_RULES, this.rules);
+        builder.add(DataComponentTypes.BUNDLE_CONTENTS, BundleContentsComponentUtil.create(this.rules));
     }
 
     @Override
@@ -170,18 +169,13 @@ public record ItemHolderItemComponent(int capacity, ItemHolderRules rules, Regis
         }
     }
 
-    private BundleContentsComponent.Builder createBuilder(ItemStack stack) {
+    public BundleContentsComponent.Builder createBuilder(ItemStack stack) {
         BundleContentsComponent existingBundleContents = stack.get(DataComponentTypes.BUNDLE_CONTENTS);
         if (existingBundleContents == null) {
             return null;
         }
-        ItemHolderRules rules = stack.get(ItematicDataComponentTypes.ITEM_HOLDER_RULES);
-        if (rules == null) {
-            return null;
-        }
         BundleContentsComponent.Builder newBuilder = new BundleContentsComponent.Builder(existingBundleContents);
         newBuilder.itematic$setCapacity(this.capacity);
-        newBuilder.itematic$setRules(rules);
         return newBuilder;
     }
 

--- a/src/main/java/net/errorcraft/itematic/item/component/components/ItemHolderItemComponent.java
+++ b/src/main/java/net/errorcraft/itematic/item/component/components/ItemHolderItemComponent.java
@@ -2,6 +2,7 @@ package net.errorcraft.itematic.item.component.components;
 
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
+import net.errorcraft.itematic.component.ItematicDataComponentTypes;
 import net.errorcraft.itematic.component.type.BundleContentsComponentUtil;
 import net.errorcraft.itematic.item.ItemStackConsumer;
 import net.errorcraft.itematic.item.component.ItemComponent;
@@ -9,6 +10,7 @@ import net.errorcraft.itematic.item.component.ItemComponentType;
 import net.errorcraft.itematic.item.component.ItemComponentTypes;
 import net.errorcraft.itematic.item.holder.rule.ItemHolderRules;
 import net.errorcraft.itematic.mixin.item.BundleItemAccessor;
+import net.errorcraft.itematic.serialization.ItematicCodecs;
 import net.errorcraft.itematic.util.Util;
 import net.minecraft.client.item.BundleTooltipData;
 import net.minecraft.client.item.TooltipData;
@@ -31,7 +33,6 @@ import net.minecraft.util.ActionResult;
 import net.minecraft.util.ClickType;
 import net.minecraft.util.Formatting;
 import net.minecraft.util.Hand;
-import net.minecraft.util.dynamic.Codecs;
 import net.minecraft.world.World;
 import org.apache.commons.lang3.math.Fraction;
 
@@ -39,9 +40,10 @@ import java.util.List;
 import java.util.Optional;
 import java.util.function.Consumer;
 
-public record ItemHolderItemComponent(int capacity, ItemHolderRules rules, RegistryEntry<SoundEvent> insertItemSound, RegistryEntry<SoundEvent> removeItemSound, RegistryEntry<SoundEvent> emptySound) implements ItemComponent<ItemHolderItemComponent> {
+public record ItemHolderItemComponent(Fraction capacity, ItemHolderRules rules, RegistryEntry<SoundEvent> insertItemSound, RegistryEntry<SoundEvent> removeItemSound, RegistryEntry<SoundEvent> emptySound) implements ItemComponent<ItemHolderItemComponent> {
+    public static final Codec<Fraction> CAPACITY_CODEC = ItematicCodecs.positiveFraction(100);
     public static final Codec<ItemHolderItemComponent> CODEC = RecordCodecBuilder.create(instance -> instance.group(
-        Codecs.POSITIVE_INT.fieldOf("capacity").forGetter(ItemHolderItemComponent::capacity),
+        CAPACITY_CODEC.fieldOf("capacity").forGetter(ItemHolderItemComponent::capacity),
         ItemHolderRules.CODEC.fieldOf("rules").forGetter(ItemHolderItemComponent::rules),
         SoundEvent.ENTRY_CODEC.fieldOf("insert_item_sound").forGetter(ItemHolderItemComponent::insertItemSound),
         SoundEvent.ENTRY_CODEC.fieldOf("remove_item_sound").forGetter(ItemHolderItemComponent::removeItemSound),
@@ -50,7 +52,7 @@ public record ItemHolderItemComponent(int capacity, ItemHolderRules rules, Regis
     public static final int ITEM_BAR_COLOR = BundleItemAccessor.itemBarColor();
 
     public static ItemHolderItemComponent of(int capacity, ItemHolderRules rules, RegistryEntry<SoundEvent> insertItemSound, RegistryEntry<SoundEvent> removeItemSound, RegistryEntry<SoundEvent> emptySound) {
-        return new ItemHolderItemComponent(capacity, rules, insertItemSound, removeItemSound, emptySound);
+        return new ItemHolderItemComponent(Fraction.getFraction(capacity, 1), rules, insertItemSound, removeItemSound, emptySound);
     }
 
     @Override
@@ -118,15 +120,19 @@ public record ItemHolderItemComponent(int capacity, ItemHolderRules rules, Regis
     @Override
     public void addComponents(ComponentMap.Builder builder) {
         builder.add(DataComponentTypes.BUNDLE_CONTENTS, BundleContentsComponentUtil.create(this.rules));
+        builder.add(ItematicDataComponentTypes.ITEM_HOLDER_CAPACITY, this.capacity);
     }
 
     @Override
     public void appendTooltip(ItemStack stack, Item.TooltipContext context, List<Text> tooltip, TooltipType type) {
         BundleContentsComponent bundleContents = stack.get(DataComponentTypes.BUNDLE_CONTENTS);
-        if (bundleContents != null) {
-            int occupancy = Util.multiplyFraction(bundleContents.getOccupancy(), Item.DEFAULT_MAX_COUNT);
-            tooltip.add(Text.translatable("item.minecraft.bundle.fullness", occupancy, this.capacity).formatted(Formatting.GRAY));
+        Fraction itemHolderCapacity = stack.get(ItematicDataComponentTypes.ITEM_HOLDER_CAPACITY);
+        if (bundleContents == null || itemHolderCapacity == null) {
+            return;
         }
+        int occupancy = Util.multiplyFraction(bundleContents.getOccupancy(), Item.DEFAULT_MAX_COUNT);
+        int capacity = Util.multiplyFraction(itemHolderCapacity, Item.DEFAULT_MAX_COUNT);
+        tooltip.add(Text.translatable("item.minecraft.bundle.fullness", occupancy, capacity).formatted(Formatting.GRAY));
     }
 
     public boolean itemBarVisible(ItemStack stack) {
@@ -149,8 +155,12 @@ public record ItemHolderItemComponent(int capacity, ItemHolderRules rules, Regis
         if (bundleContents == null) {
             return Optional.empty();
         }
+        Fraction capacity = stack.get(ItematicDataComponentTypes.ITEM_HOLDER_CAPACITY);
+        if (capacity == null) {
+            return Optional.empty();
+        }
         BundleTooltipData data = new BundleTooltipData(bundleContents);
-        data.itematic$setCapacity(this.capacity);
+        data.itematic$setCapacity(capacity);
         return Optional.of(data);
     }
 
@@ -159,7 +169,11 @@ public record ItemHolderItemComponent(int capacity, ItemHolderRules rules, Regis
         if (bundleContents == null) {
             return Fraction.ZERO;
         }
-        return bundleContents.getOccupancy().multiplyBy(Fraction.getFraction(1, this.capacity));
+        Fraction capacity = stack.get(ItematicDataComponentTypes.ITEM_HOLDER_CAPACITY);
+        if (capacity == null) {
+            return Fraction.ZERO;
+        }
+        return bundleContents.getOccupancy().divideBy(capacity);
     }
 
     public void onDestroyed(ItemEntity item) {
@@ -174,8 +188,12 @@ public record ItemHolderItemComponent(int capacity, ItemHolderRules rules, Regis
         if (existingBundleContents == null) {
             return null;
         }
+        Fraction capacity = stack.get(ItematicDataComponentTypes.ITEM_HOLDER_CAPACITY);
+        if (capacity == null) {
+            return null;
+        }
         BundleContentsComponent.Builder newBuilder = new BundleContentsComponent.Builder(existingBundleContents);
-        newBuilder.itematic$setCapacity(this.capacity);
+        newBuilder.itematic$setCapacity(capacity);
         return newBuilder;
     }
 

--- a/src/main/java/net/errorcraft/itematic/item/component/components/ItemHolderItemComponent.java
+++ b/src/main/java/net/errorcraft/itematic/item/component/components/ItemHolderItemComponent.java
@@ -2,6 +2,8 @@ package net.errorcraft.itematic.item.component.components;
 
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
+import net.errorcraft.itematic.component.ItematicDataComponentTypes;
+import net.errorcraft.itematic.item.holder.rule.ItemHolderRules;
 import net.errorcraft.itematic.item.ItemStackConsumer;
 import net.errorcraft.itematic.item.component.ItemComponent;
 import net.errorcraft.itematic.item.component.ItemComponentType;
@@ -37,14 +39,19 @@ import java.util.List;
 import java.util.Optional;
 import java.util.function.Consumer;
 
-public record ItemHolderItemComponent(int capacity, RegistryEntry<SoundEvent> insertItemSound, RegistryEntry<SoundEvent> removeItemSound, RegistryEntry<SoundEvent> emptySound) implements ItemComponent<ItemHolderItemComponent> {
+public record ItemHolderItemComponent(int capacity, ItemHolderRules rules, RegistryEntry<SoundEvent> insertItemSound, RegistryEntry<SoundEvent> removeItemSound, RegistryEntry<SoundEvent> emptySound) implements ItemComponent<ItemHolderItemComponent> {
     public static final Codec<ItemHolderItemComponent> CODEC = RecordCodecBuilder.create(instance -> instance.group(
         Codecs.POSITIVE_INT.fieldOf("capacity").forGetter(ItemHolderItemComponent::capacity),
+        ItemHolderRules.CODEC.fieldOf("rules").forGetter(ItemHolderItemComponent::rules),
         SoundEvent.ENTRY_CODEC.fieldOf("insert_item_sound").forGetter(ItemHolderItemComponent::insertItemSound),
         SoundEvent.ENTRY_CODEC.fieldOf("remove_item_sound").forGetter(ItemHolderItemComponent::removeItemSound),
         SoundEvent.ENTRY_CODEC.fieldOf("empty_sound").forGetter(ItemHolderItemComponent::emptySound)
     ).apply(instance, ItemHolderItemComponent::new));
     public static final int ITEM_BAR_COLOR = BundleItemAccessor.itemBarColor();
+
+    public static ItemHolderItemComponent of(int capacity, ItemHolderRules rules, RegistryEntry<SoundEvent> insertItemSound, RegistryEntry<SoundEvent> removeItemSound, RegistryEntry<SoundEvent> emptySound) {
+        return new ItemHolderItemComponent(capacity, rules, insertItemSound, removeItemSound, emptySound);
+    }
 
     @Override
     public ItemComponentType<ItemHolderItemComponent> type() {
@@ -72,20 +79,18 @@ public record ItemHolderItemComponent(int capacity, RegistryEntry<SoundEvent> in
             return false;
         }
 
-        BundleContentsComponent bundleContents = stack.get(DataComponentTypes.BUNDLE_CONTENTS);
-        if (bundleContents == null) {
+        BundleContentsComponent.Builder newBuilder = this.createBuilder(stack);
+        if (newBuilder == null) {
             return false;
         }
 
-        BundleContentsComponent.Builder bundleContentsBuilder = new BundleContentsComponent.Builder(bundleContents);
-        bundleContentsBuilder.itematic$setCapacity(this.capacity);
         if (slot.getStack().isEmpty()) {
-            this.remove(user, bundleContentsBuilder, removedStack -> this.add(bundleContentsBuilder, slot.insertStack(removedStack), user));
+            this.remove(user, newBuilder, removedStack -> this.add(newBuilder, slot.insertStack(removedStack), user));
         } else {
-            this.add(bundleContentsBuilder, slot, user);
+            this.add(newBuilder, slot, user);
         }
 
-        stack.set(DataComponentTypes.BUNDLE_CONTENTS, bundleContentsBuilder.build());
+        stack.set(DataComponentTypes.BUNDLE_CONTENTS, newBuilder.build());
         return true;
     }
 
@@ -95,26 +100,25 @@ public record ItemHolderItemComponent(int capacity, RegistryEntry<SoundEvent> in
             return false;
         }
 
-        BundleContentsComponent bundleContents = stack.get(DataComponentTypes.BUNDLE_CONTENTS);
-        if (bundleContents == null) {
+        BundleContentsComponent.Builder newBuilder = this.createBuilder(stack);
+        if (newBuilder == null) {
             return false;
         }
 
-        BundleContentsComponent.Builder bundleContentsBuilder = new BundleContentsComponent.Builder(bundleContents);
-        bundleContentsBuilder.itematic$setCapacity(this.capacity);
         if (cursorStack.isEmpty()) {
-            this.remove(user, bundleContentsBuilder, resultStackConsumer::set);
+            this.remove(user, newBuilder, resultStackConsumer::set);
         } else {
-            this.add(bundleContentsBuilder, cursorStack, user);
+            this.add(newBuilder, cursorStack, user);
         }
 
-        stack.set(DataComponentTypes.BUNDLE_CONTENTS, bundleContentsBuilder.build());
+        stack.set(DataComponentTypes.BUNDLE_CONTENTS, newBuilder.build());
         return true;
     }
 
     @Override
     public void addComponents(ComponentMap.Builder builder) {
         builder.add(DataComponentTypes.BUNDLE_CONTENTS, BundleContentsComponent.DEFAULT);
+        builder.add(ItematicDataComponentTypes.ITEM_HOLDER_RULES, this.rules);
     }
 
     @Override
@@ -166,8 +170,19 @@ public record ItemHolderItemComponent(int capacity, RegistryEntry<SoundEvent> in
         }
     }
 
-    public static ItemHolderItemComponent of(int capacity, RegistryEntry<SoundEvent> insertItemSound, RegistryEntry<SoundEvent> removeItemSound, RegistryEntry<SoundEvent> emptySound) {
-        return new ItemHolderItemComponent(capacity, insertItemSound, removeItemSound, emptySound);
+    private BundleContentsComponent.Builder createBuilder(ItemStack stack) {
+        BundleContentsComponent existingBundleContents = stack.get(DataComponentTypes.BUNDLE_CONTENTS);
+        if (existingBundleContents == null) {
+            return null;
+        }
+        ItemHolderRules rules = stack.get(ItematicDataComponentTypes.ITEM_HOLDER_RULES);
+        if (rules == null) {
+            return null;
+        }
+        BundleContentsComponent.Builder newBuilder = new BundleContentsComponent.Builder(existingBundleContents);
+        newBuilder.itematic$setCapacity(this.capacity);
+        newBuilder.itematic$setRules(rules);
+        return newBuilder;
     }
 
     private void add(BundleContentsComponent.Builder bundleContentsBuilder, ItemStack stack, PlayerEntity user) {

--- a/src/main/java/net/errorcraft/itematic/item/holder/rule/ItemHolderRule.java
+++ b/src/main/java/net/errorcraft/itematic/item/holder/rule/ItemHolderRule.java
@@ -1,0 +1,19 @@
+package net.errorcraft.itematic.item.holder.rule;
+
+import com.mojang.serialization.MapCodec;
+import net.errorcraft.itematic.registry.ItematicRegistries;
+import net.errorcraft.itematic.registry.ItematicRegistryKeys;
+import net.minecraft.item.ItemStack;
+import net.minecraft.network.RegistryByteBuf;
+import net.minecraft.network.codec.PacketCodec;
+import net.minecraft.network.codec.PacketCodecs;
+import org.apache.commons.lang3.math.Fraction;
+
+public interface ItemHolderRule {
+    MapCodec<ItemHolderRule> CODEC = ItematicRegistries.ITEM_HOLDER_RULE_TYPE.getCodec().dispatchMap("type", ItemHolderRule::type, ItemHolderRuleType::codec);
+    PacketCodec<RegistryByteBuf, ItemHolderRule> PACKET_CODEC = PacketCodecs.registryValue(ItematicRegistryKeys.ITEM_HOLDER_RULE_TYPE).dispatch(ItemHolderRule::type, ItemHolderRuleType::packetCodec);
+
+    ItemHolderRuleType<?> type();
+    Fraction occupancy(ItemStack stack);
+    boolean canOccupy(ItemStack stack);
+}

--- a/src/main/java/net/errorcraft/itematic/item/holder/rule/ItemHolderRuleType.java
+++ b/src/main/java/net/errorcraft/itematic/item/holder/rule/ItemHolderRuleType.java
@@ -1,0 +1,8 @@
+package net.errorcraft.itematic.item.holder.rule;
+
+import com.mojang.serialization.MapCodec;
+import net.minecraft.network.RegistryByteBuf;
+import net.minecraft.network.codec.PacketCodec;
+
+public record ItemHolderRuleType<T extends ItemHolderRule>(MapCodec<T> codec, PacketCodec<? super RegistryByteBuf, T> packetCodec) {
+}

--- a/src/main/java/net/errorcraft/itematic/item/holder/rule/ItemHolderRuleTypeKeys.java
+++ b/src/main/java/net/errorcraft/itematic/item/holder/rule/ItemHolderRuleTypeKeys.java
@@ -1,0 +1,17 @@
+package net.errorcraft.itematic.item.holder.rule;
+
+import net.errorcraft.itematic.registry.ItematicRegistryKeys;
+import net.minecraft.registry.RegistryKey;
+import net.minecraft.util.Identifier;
+
+public class ItemHolderRuleTypeKeys {
+    public static final RegistryKey<ItemHolderRuleType<?>> REJECT = of("reject");
+    public static final RegistryKey<ItemHolderRuleType<?>> FRACTION_WITH_OCCUPANCY_HELD_ITEMS = of("fraction_with_occupancy_held_items");
+    public static final RegistryKey<ItemHolderRuleType<?>> FRACTION = of("fraction");
+
+    private ItemHolderRuleTypeKeys() {}
+
+    private static RegistryKey<ItemHolderRuleType<?>> of(String id) {
+        return RegistryKey.of(ItematicRegistryKeys.ITEM_HOLDER_RULE_TYPE, new Identifier(id));
+    }
+}

--- a/src/main/java/net/errorcraft/itematic/item/holder/rule/ItemHolderRuleTypes.java
+++ b/src/main/java/net/errorcraft/itematic/item/holder/rule/ItemHolderRuleTypes.java
@@ -1,0 +1,22 @@
+package net.errorcraft.itematic.item.holder.rule;
+
+import net.errorcraft.itematic.item.holder.rule.rules.FractionItemHolderRule;
+import net.errorcraft.itematic.item.holder.rule.rules.FractionWithOccupancyHeldItemsItemHolderRule;
+import net.errorcraft.itematic.item.holder.rule.rules.RejectItemHolderRule;
+import net.errorcraft.itematic.registry.ItematicRegistries;
+import net.minecraft.registry.Registry;
+import net.minecraft.registry.RegistryKey;
+
+public class ItemHolderRuleTypes {
+    public static final ItemHolderRuleType<RejectItemHolderRule> REJECT = register(ItemHolderRuleTypeKeys.REJECT, new ItemHolderRuleType<>(RejectItemHolderRule.CODEC, RejectItemHolderRule.PACKET_CODEC));
+    public static final ItemHolderRuleType<FractionWithOccupancyHeldItemsItemHolderRule> FRACTION_WITH_OCCUPANCY_HELD_ITEMS = register(ItemHolderRuleTypeKeys.FRACTION_WITH_OCCUPANCY_HELD_ITEMS, new ItemHolderRuleType<>(FractionWithOccupancyHeldItemsItemHolderRule.CODEC, FractionWithOccupancyHeldItemsItemHolderRule.PACKET_CODEC));
+    public static final ItemHolderRuleType<FractionItemHolderRule> FRACTION = register(ItemHolderRuleTypeKeys.FRACTION, new ItemHolderRuleType<>(FractionItemHolderRule.CODEC, FractionItemHolderRule.PACKET_CODEC));
+
+    private ItemHolderRuleTypes() {}
+
+    public static void init() {}
+
+    private static <T extends ItemHolderRule> ItemHolderRuleType<T> register(RegistryKey<ItemHolderRuleType<?>> id, ItemHolderRuleType<T> type) {
+        return Registry.register(ItematicRegistries.ITEM_HOLDER_RULE_TYPE, id, type);
+    }
+}

--- a/src/main/java/net/errorcraft/itematic/item/holder/rule/ItemHolderRules.java
+++ b/src/main/java/net/errorcraft/itematic/item/holder/rule/ItemHolderRules.java
@@ -1,0 +1,77 @@
+package net.errorcraft.itematic.item.holder.rule;
+
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+import net.errorcraft.itematic.predicate.item.ItemPredicateUtil;
+import net.minecraft.item.ItemStack;
+import net.minecraft.network.RegistryByteBuf;
+import net.minecraft.network.codec.PacketCodec;
+import net.minecraft.network.codec.PacketCodecs;
+import net.minecraft.predicate.item.ItemPredicate;
+import org.apache.commons.lang3.math.Fraction;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+public record ItemHolderRules(List<Rule> rules) {
+    public static final Codec<ItemHolderRules> CODEC = Rule.CODEC.listOf().xmap(ItemHolderRules::new, ItemHolderRules::rules);
+    public static final PacketCodec<RegistryByteBuf, ItemHolderRules> PACKET_CODEC = Rule.PACKET_CODEC.collect(PacketCodecs.toList()).xmap(ItemHolderRules::new, ItemHolderRules::rules);
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public Fraction occupancy(ItemStack stack) {
+        for (Rule rule : this.rules) {
+            if (rule.test(stack)) {
+                return rule.rule.occupancy(stack);
+            }
+        }
+        return Fraction.getFraction(1, stack.getMaxCount());
+    }
+
+    public boolean canOccupy(ItemStack stack) {
+        for (Rule rule : this.rules) {
+            if (rule.test(stack)) {
+                return rule.rule.canOccupy(stack);
+            }
+        }
+        return true;
+    }
+
+    public static class Builder {
+        private final List<Rule> rules = new ArrayList<>();
+
+        public ItemHolderRules build() {
+            return new ItemHolderRules(this.rules);
+        }
+
+        public Builder rule(ItemHolderRule rule) {
+            this.rules.add(new Rule(Optional.empty(), rule));
+            return this;
+        }
+
+        public Builder rule(ItemHolderRule rule, ItemPredicate condition) {
+            this.rules.add(new Rule(Optional.of(condition), rule));
+            return this;
+        }
+    }
+
+    public record Rule(Optional<ItemPredicate> condition, ItemHolderRule rule) {
+        public static final Codec<Rule> CODEC = RecordCodecBuilder.create(instance -> instance.group(
+            ItemPredicate.CODEC.optionalFieldOf("condition").forGetter(Rule::condition),
+            ItemHolderRule.CODEC.forGetter(Rule::rule)
+        ).apply(instance, Rule::new));
+        public static final PacketCodec<RegistryByteBuf, Rule> PACKET_CODEC = PacketCodec.tuple(
+            ItemPredicateUtil.PACKET_CODEC.collect(PacketCodecs::optional), Rule::condition,
+            ItemHolderRule.PACKET_CODEC, Rule::rule,
+            Rule::new
+        );
+
+        public boolean test(ItemStack stack) {
+            return this.condition.map(predicate -> predicate.test(stack))
+                .orElse(true);
+        }
+    }
+}

--- a/src/main/java/net/errorcraft/itematic/item/holder/rule/rules/FractionItemHolderRule.java
+++ b/src/main/java/net/errorcraft/itematic/item/holder/rule/rules/FractionItemHolderRule.java
@@ -1,0 +1,39 @@
+package net.errorcraft.itematic.item.holder.rule.rules;
+
+import com.mojang.serialization.MapCodec;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+import io.netty.buffer.ByteBuf;
+import net.errorcraft.itematic.item.holder.rule.ItemHolderRule;
+import net.errorcraft.itematic.item.holder.rule.ItemHolderRuleType;
+import net.errorcraft.itematic.item.holder.rule.ItemHolderRuleTypes;
+import net.errorcraft.itematic.network.codec.PacketCodecUtil;
+import net.errorcraft.itematic.serialization.ItematicCodecs;
+import net.minecraft.item.ItemStack;
+import net.minecraft.network.codec.PacketCodec;
+import org.apache.commons.lang3.math.Fraction;
+
+public record FractionItemHolderRule(Fraction fraction) implements ItemHolderRule {
+    public static final MapCodec<FractionItemHolderRule> CODEC = RecordCodecBuilder.mapCodec(instance -> instance.group(
+        ItematicCodecs.POSITIVE_FRACTION.fieldOf("fraction").forGetter(FractionItemHolderRule::fraction)
+    ).apply(instance, FractionItemHolderRule::new));
+    public static final PacketCodec<ByteBuf, FractionItemHolderRule> PACKET_CODEC = PacketCodecUtil.FRACTION.xmap(FractionItemHolderRule::new, FractionItemHolderRule::fraction);
+
+    public static FractionItemHolderRule of(int numerator, int denominator) {
+        return new FractionItemHolderRule(Fraction.getFraction(numerator, denominator));
+    }
+
+    @Override
+    public ItemHolderRuleType<?> type() {
+        return ItemHolderRuleTypes.FRACTION;
+    }
+
+    @Override
+    public Fraction occupancy(ItemStack stack) {
+        return this.fraction;
+    }
+
+    @Override
+    public boolean canOccupy(ItemStack stack) {
+        return true;
+    }
+}

--- a/src/main/java/net/errorcraft/itematic/item/holder/rule/rules/FractionItemHolderRule.java
+++ b/src/main/java/net/errorcraft/itematic/item/holder/rule/rules/FractionItemHolderRule.java
@@ -18,8 +18,8 @@ public record FractionItemHolderRule(Fraction fraction) implements ItemHolderRul
     ).apply(instance, FractionItemHolderRule::new));
     public static final PacketCodec<ByteBuf, FractionItemHolderRule> PACKET_CODEC = PacketCodecUtil.FRACTION.xmap(FractionItemHolderRule::new, FractionItemHolderRule::fraction);
 
-    public static FractionItemHolderRule of(int numerator, int denominator) {
-        return new FractionItemHolderRule(Fraction.getFraction(numerator, denominator));
+    public static FractionItemHolderRule of(Fraction fraction) {
+        return new FractionItemHolderRule(fraction);
     }
 
     @Override

--- a/src/main/java/net/errorcraft/itematic/item/holder/rule/rules/FractionItemHolderRule.java
+++ b/src/main/java/net/errorcraft/itematic/item/holder/rule/rules/FractionItemHolderRule.java
@@ -3,18 +3,18 @@ package net.errorcraft.itematic.item.holder.rule.rules;
 import com.mojang.serialization.MapCodec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 import io.netty.buffer.ByteBuf;
+import net.errorcraft.itematic.item.component.components.ItemHolderItemComponent;
 import net.errorcraft.itematic.item.holder.rule.ItemHolderRule;
 import net.errorcraft.itematic.item.holder.rule.ItemHolderRuleType;
 import net.errorcraft.itematic.item.holder.rule.ItemHolderRuleTypes;
 import net.errorcraft.itematic.network.codec.PacketCodecUtil;
-import net.errorcraft.itematic.serialization.ItematicCodecs;
 import net.minecraft.item.ItemStack;
 import net.minecraft.network.codec.PacketCodec;
 import org.apache.commons.lang3.math.Fraction;
 
 public record FractionItemHolderRule(Fraction fraction) implements ItemHolderRule {
     public static final MapCodec<FractionItemHolderRule> CODEC = RecordCodecBuilder.mapCodec(instance -> instance.group(
-        ItematicCodecs.POSITIVE_FRACTION.fieldOf("fraction").forGetter(FractionItemHolderRule::fraction)
+        ItemHolderItemComponent.CAPACITY_CODEC.fieldOf("fraction").forGetter(FractionItemHolderRule::fraction)
     ).apply(instance, FractionItemHolderRule::new));
     public static final PacketCodec<ByteBuf, FractionItemHolderRule> PACKET_CODEC = PacketCodecUtil.FRACTION.xmap(FractionItemHolderRule::new, FractionItemHolderRule::fraction);
 

--- a/src/main/java/net/errorcraft/itematic/item/holder/rule/rules/FractionWithOccupancyHeldItemsItemHolderRule.java
+++ b/src/main/java/net/errorcraft/itematic/item/holder/rule/rules/FractionWithOccupancyHeldItemsItemHolderRule.java
@@ -4,11 +4,11 @@ import com.mojang.serialization.MapCodec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 import io.netty.buffer.ByteBuf;
 import net.errorcraft.itematic.item.component.ItemComponentTypes;
+import net.errorcraft.itematic.item.component.components.ItemHolderItemComponent;
 import net.errorcraft.itematic.item.holder.rule.ItemHolderRule;
 import net.errorcraft.itematic.item.holder.rule.ItemHolderRuleType;
 import net.errorcraft.itematic.item.holder.rule.ItemHolderRuleTypes;
 import net.errorcraft.itematic.network.codec.PacketCodecUtil;
-import net.errorcraft.itematic.serialization.ItematicCodecs;
 import net.minecraft.component.DataComponentTypes;
 import net.minecraft.component.type.BundleContentsComponent;
 import net.minecraft.item.ItemStack;
@@ -17,7 +17,7 @@ import org.apache.commons.lang3.math.Fraction;
 
 public record FractionWithOccupancyHeldItemsItemHolderRule(Fraction fraction) implements ItemHolderRule {
     public static final MapCodec<FractionWithOccupancyHeldItemsItemHolderRule> CODEC = RecordCodecBuilder.mapCodec(instance -> instance.group(
-        ItematicCodecs.POSITIVE_FRACTION.fieldOf("fraction").forGetter(FractionWithOccupancyHeldItemsItemHolderRule::fraction)
+        ItemHolderItemComponent.CAPACITY_CODEC.fieldOf("fraction").forGetter(FractionWithOccupancyHeldItemsItemHolderRule::fraction)
     ).apply(instance, FractionWithOccupancyHeldItemsItemHolderRule::new));
     public static final PacketCodec<ByteBuf, FractionWithOccupancyHeldItemsItemHolderRule> PACKET_CODEC = PacketCodecUtil.FRACTION.xmap(FractionWithOccupancyHeldItemsItemHolderRule::new, FractionWithOccupancyHeldItemsItemHolderRule::fraction);
 

--- a/src/main/java/net/errorcraft/itematic/item/holder/rule/rules/FractionWithOccupancyHeldItemsItemHolderRule.java
+++ b/src/main/java/net/errorcraft/itematic/item/holder/rule/rules/FractionWithOccupancyHeldItemsItemHolderRule.java
@@ -1,0 +1,49 @@
+package net.errorcraft.itematic.item.holder.rule.rules;
+
+import com.mojang.serialization.MapCodec;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+import io.netty.buffer.ByteBuf;
+import net.errorcraft.itematic.item.component.ItemComponentTypes;
+import net.errorcraft.itematic.item.holder.rule.ItemHolderRule;
+import net.errorcraft.itematic.item.holder.rule.ItemHolderRuleType;
+import net.errorcraft.itematic.item.holder.rule.ItemHolderRuleTypes;
+import net.errorcraft.itematic.network.codec.PacketCodecUtil;
+import net.errorcraft.itematic.serialization.ItematicCodecs;
+import net.minecraft.component.DataComponentTypes;
+import net.minecraft.component.type.BundleContentsComponent;
+import net.minecraft.item.ItemStack;
+import net.minecraft.network.codec.PacketCodec;
+import org.apache.commons.lang3.math.Fraction;
+
+public record FractionWithOccupancyHeldItemsItemHolderRule(Fraction fraction) implements ItemHolderRule {
+    public static final MapCodec<FractionWithOccupancyHeldItemsItemHolderRule> CODEC = RecordCodecBuilder.mapCodec(instance -> instance.group(
+        ItematicCodecs.POSITIVE_FRACTION.fieldOf("fraction").forGetter(FractionWithOccupancyHeldItemsItemHolderRule::fraction)
+    ).apply(instance, FractionWithOccupancyHeldItemsItemHolderRule::new));
+    public static final PacketCodec<ByteBuf, FractionWithOccupancyHeldItemsItemHolderRule> PACKET_CODEC = PacketCodecUtil.FRACTION.xmap(FractionWithOccupancyHeldItemsItemHolderRule::new, FractionWithOccupancyHeldItemsItemHolderRule::fraction);
+
+    public static FractionWithOccupancyHeldItemsItemHolderRule of(int numerator, int denominator) {
+        return new FractionWithOccupancyHeldItemsItemHolderRule(Fraction.getFraction(numerator, denominator));
+    }
+
+    @Override
+    public ItemHolderRuleType<?> type() {
+        return ItemHolderRuleTypes.FRACTION_WITH_OCCUPANCY_HELD_ITEMS;
+    }
+
+    @Override
+    public Fraction occupancy(ItemStack stack) {
+        if (!stack.itematic$hasComponent(ItemComponentTypes.ITEM_HOLDER)) {
+            return this.fraction;
+        }
+        BundleContentsComponent bundleContents = stack.get(DataComponentTypes.BUNDLE_CONTENTS);
+        if (bundleContents == null) {
+            return this.fraction;
+        }
+        return this.fraction.add(bundleContents.getOccupancy());
+    }
+
+    @Override
+    public boolean canOccupy(ItemStack stack) {
+        return true;
+    }
+}

--- a/src/main/java/net/errorcraft/itematic/item/holder/rule/rules/FractionWithOccupancyHeldItemsItemHolderRule.java
+++ b/src/main/java/net/errorcraft/itematic/item/holder/rule/rules/FractionWithOccupancyHeldItemsItemHolderRule.java
@@ -21,8 +21,8 @@ public record FractionWithOccupancyHeldItemsItemHolderRule(Fraction fraction) im
     ).apply(instance, FractionWithOccupancyHeldItemsItemHolderRule::new));
     public static final PacketCodec<ByteBuf, FractionWithOccupancyHeldItemsItemHolderRule> PACKET_CODEC = PacketCodecUtil.FRACTION.xmap(FractionWithOccupancyHeldItemsItemHolderRule::new, FractionWithOccupancyHeldItemsItemHolderRule::fraction);
 
-    public static FractionWithOccupancyHeldItemsItemHolderRule of(int numerator, int denominator) {
-        return new FractionWithOccupancyHeldItemsItemHolderRule(Fraction.getFraction(numerator, denominator));
+    public static FractionWithOccupancyHeldItemsItemHolderRule of(Fraction fraction) {
+        return new FractionWithOccupancyHeldItemsItemHolderRule(fraction);
     }
 
     @Override

--- a/src/main/java/net/errorcraft/itematic/item/holder/rule/rules/RejectItemHolderRule.java
+++ b/src/main/java/net/errorcraft/itematic/item/holder/rule/rules/RejectItemHolderRule.java
@@ -1,0 +1,31 @@
+package net.errorcraft.itematic.item.holder.rule.rules;
+
+import com.mojang.serialization.MapCodec;
+import io.netty.buffer.ByteBuf;
+import net.errorcraft.itematic.item.holder.rule.ItemHolderRule;
+import net.errorcraft.itematic.item.holder.rule.ItemHolderRuleType;
+import net.errorcraft.itematic.item.holder.rule.ItemHolderRuleTypes;
+import net.minecraft.item.ItemStack;
+import net.minecraft.network.codec.PacketCodec;
+import org.apache.commons.lang3.math.Fraction;
+
+public record RejectItemHolderRule() implements ItemHolderRule {
+    public static final RejectItemHolderRule INSTANCE = new RejectItemHolderRule();
+    public static final MapCodec<RejectItemHolderRule> CODEC = MapCodec.unit(INSTANCE);
+    public static final PacketCodec<ByteBuf, RejectItemHolderRule> PACKET_CODEC = PacketCodec.unit(INSTANCE);
+
+    @Override
+    public ItemHolderRuleType<?> type() {
+        return ItemHolderRuleTypes.REJECT;
+    }
+
+    @Override
+    public Fraction occupancy(ItemStack stack) {
+        return Fraction.ZERO;
+    }
+
+    @Override
+    public boolean canOccupy(ItemStack stack) {
+        return false;
+    }
+}

--- a/src/main/java/net/errorcraft/itematic/mixin/client/item/BundleTooltipDataExtender.java
+++ b/src/main/java/net/errorcraft/itematic/mixin/client/item/BundleTooltipDataExtender.java
@@ -2,21 +2,22 @@ package net.errorcraft.itematic.mixin.client.item;
 
 import net.errorcraft.itematic.access.client.item.BundleTooltipDataAccess;
 import net.minecraft.client.item.BundleTooltipData;
+import org.apache.commons.lang3.math.Fraction;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Unique;
 
 @Mixin(BundleTooltipData.class)
 public class BundleTooltipDataExtender implements BundleTooltipDataAccess {
     @Unique
-    private int capacity;
+    private Fraction capacity;
 
     @Override
-    public int itematic$capacity() {
+    public Fraction itematic$capacity() {
         return this.capacity;
     }
 
     @Override
-    public void itematic$setCapacity(int capacity) {
+    public void itematic$setCapacity(Fraction capacity) {
         this.capacity = capacity;
     }
 }

--- a/src/main/java/net/errorcraft/itematic/mixin/component/type/BundleContentsComponentAccessor.java
+++ b/src/main/java/net/errorcraft/itematic/mixin/component/type/BundleContentsComponentAccessor.java
@@ -1,0 +1,14 @@
+package net.errorcraft.itematic.mixin.component.type;
+
+import net.minecraft.component.type.BundleContentsComponent;
+import org.apache.commons.lang3.math.Fraction;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+@Mixin(BundleContentsComponent.class)
+public interface BundleContentsComponentAccessor {
+    @Accessor("NESTED_BUNDLE_OCCUPANCY")
+    static Fraction nestedBundleOccupancy() {
+        throw new AssertionError();
+    }
+}

--- a/src/main/java/net/errorcraft/itematic/mixin/component/type/BundleContentsComponentExtender.java
+++ b/src/main/java/net/errorcraft/itematic/mixin/component/type/BundleContentsComponentExtender.java
@@ -2,10 +2,12 @@ package net.errorcraft.itematic.mixin.component.type;
 
 import com.llamalad7.mixinextras.sugar.Local;
 import net.errorcraft.itematic.access.component.type.BundleContentsComponentBuilderAccess;
+import net.errorcraft.itematic.item.holder.rule.ItemHolderRules;
 import net.minecraft.component.type.BundleContentsComponent;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import org.apache.commons.lang3.math.Fraction;
+import org.objectweb.asm.Opcodes;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
@@ -28,16 +30,42 @@ public class BundleContentsComponentExtender {
         @Unique
         private Fraction capacity;
 
+        @Unique
+        private ItemHolderRules rules;
+
         @Redirect(
             method = "getMaxAllowed",
             at = @At(
                 value = "FIELD",
                 target = "Lorg/apache/commons/lang3/math/Fraction;ONE:Lorg/apache/commons/lang3/math/Fraction;",
+                opcode = Opcodes.GETSTATIC,
                 remap = false
             )
         )
         private Fraction getCapacity() {
             return this.capacity;
+        }
+
+        @Redirect(
+            method = { "getMaxAllowed", "add(Lnet/minecraft/item/ItemStack;)I", "removeFirst" },
+            at = @At(
+                value = "INVOKE",
+                target = "Lnet/minecraft/component/type/BundleContentsComponent;getOccupancy(Lnet/minecraft/item/ItemStack;)Lorg/apache/commons/lang3/math/Fraction;"
+            )
+        )
+        private Fraction calculateFromDataComponent(ItemStack stack) {
+            return this.rules.occupancy(stack);
+        }
+
+        @Redirect(
+            method = "add(Lnet/minecraft/item/ItemStack;)I",
+            at = @At(
+                value = "INVOKE",
+                target = "Lnet/minecraft/item/Item;canBeNested()Z"
+            )
+        )
+        private boolean checkFromDataComponent(Item instance, ItemStack stack) {
+            return this.rules.canOccupy(stack);
         }
 
         @Inject(
@@ -68,6 +96,11 @@ public class BundleContentsComponentExtender {
         @Override
         public void itematic$setCapacity(int capacity) {
             this.capacity = Fraction.getFraction(capacity, Item.DEFAULT_MAX_COUNT);
+        }
+
+        @Override
+        public void itematic$setRules(ItemHolderRules rules) {
+            this.rules = rules;
         }
     }
 }

--- a/src/main/java/net/errorcraft/itematic/mixin/component/type/BundleContentsComponentExtender.java
+++ b/src/main/java/net/errorcraft/itematic/mixin/component/type/BundleContentsComponentExtender.java
@@ -1,26 +1,150 @@
 package net.errorcraft.itematic.mixin.component.type;
 
+import com.llamalad7.mixinextras.injector.ModifyReturnValue;
 import com.llamalad7.mixinextras.sugar.Local;
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+import net.errorcraft.itematic.access.component.type.BundleContentsComponentAccess;
 import net.errorcraft.itematic.access.component.type.BundleContentsComponentBuilderAccess;
+import net.errorcraft.itematic.component.type.BundleContentsComponentExtraFields;
+import net.errorcraft.itematic.component.type.BundleContentsComponentUtil;
 import net.errorcraft.itematic.item.holder.rule.ItemHolderRules;
 import net.minecraft.component.type.BundleContentsComponent;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
+import net.minecraft.network.RegistryByteBuf;
+import net.minecraft.network.codec.PacketCodec;
 import org.apache.commons.lang3.math.Fraction;
 import org.objectweb.asm.Opcodes;
-import org.spongepowered.asm.mixin.Final;
-import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Shadow;
-import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.*;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.Redirect;
+import org.spongepowered.asm.mixin.injection.Slice;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 import java.util.List;
+import java.util.Objects;
+import java.util.function.Function;
 
 @Mixin(BundleContentsComponent.class)
-public class BundleContentsComponentExtender {
+public class BundleContentsComponentExtender implements BundleContentsComponentAccess {
+    @Shadow
+    @Final
+    List<ItemStack> stacks;
+
+    @Shadow
+    @Final
+    @Mutable
+    Fraction occupancy;
+
+    @Unique
+    private BundleContentsComponentExtraFields extraFields;
+
+    @Redirect(
+        method = "<clinit>",
+        at = @At(
+            value = "INVOKE",
+            target = "Lcom/mojang/serialization/Codec;xmap(Ljava/util/function/Function;Ljava/util/function/Function;)Lcom/mojang/serialization/Codec;",
+            remap = false
+        )
+    )
+    private static Codec<BundleContentsComponent> createCodecAddExtraFields(Codec<List<ItemStack>> instance, Function<List<ItemStack>, BundleContentsComponent> to, Function<BundleContentsComponent, List<ItemStack>> from) {
+        Codec<BundleContentsComponent> fullCodec = RecordCodecBuilder.create(i -> i.group(
+            BundleContentsComponentExtraFields.CODEC.optionalFieldOf("rules", BundleContentsComponentExtraFields.DEFAULT).forGetter(BundleContentsComponent::itematic$extraFields),
+            instance.fieldOf("items").forGetter(BundleContentsComponent::itematic$stacks)
+        ).apply(i, BundleContentsComponentUtil::create));
+        return Codec.withAlternative(
+            fullCodec,
+            instance.xmap(BundleContentsComponentExtender::create, BundleContentsComponent::itematic$stacks)
+        );
+    }
+
+    @Redirect(
+        method = "<clinit>",
+        at = @At(
+            value = "INVOKE",
+            target = "Lnet/minecraft/network/codec/PacketCodec;xmap(Ljava/util/function/Function;Ljava/util/function/Function;)Lnet/minecraft/network/codec/PacketCodec;"
+        )
+    )
+    private static PacketCodec<RegistryByteBuf, BundleContentsComponent> createPacketCodecAddExtraFields(PacketCodec<RegistryByteBuf, List<ItemStack>> instance, Function<List<ItemStack>, BundleContentsComponent> to, Function<BundleContentsComponent, List<ItemStack>> from) {
+        return PacketCodec.tuple(
+            BundleContentsComponentExtraFields.PACKET_CODEC, BundleContentsComponent::itematic$extraFields,
+            instance, BundleContentsComponent::itematic$stacks,
+            BundleContentsComponentUtil::create
+        );
+    }
+
+    @Redirect(
+        method = "<init>(Ljava/util/List;)V",
+        at = @At(
+            value = "INVOKE",
+            target = "Lnet/minecraft/component/type/BundleContentsComponent;calculateOccupancy(Ljava/util/List;)Lorg/apache/commons/lang3/math/Fraction;"
+        )
+    )
+    private static Fraction doNotCalculateOccupancy(List<ItemStack> stacks) {
+        return Fraction.ZERO;
+    }
+
+    @ModifyReturnValue(
+        method = "hashCode",
+        at = @At("RETURN"),
+        remap = false
+    )
+    private int calculateHashCodeFromExtraFields(int original) {
+        return Objects.hash(original, this.extraFields);
+    }
+
+    @ModifyReturnValue(
+        method = "equals",
+        at = @At(
+            value = "RETURN",
+            ordinal = 0
+        ),
+        slice = @Slice(
+            from = @At(
+                value = "INVOKE",
+                target = "Lorg/apache/commons/lang3/math/Fraction;equals(Ljava/lang/Object;)Z"
+            )
+        ),
+        remap = false
+    )
+    private boolean checkExtraFields(boolean original, @Local(argsOnly = true) Object that) {
+        return original && Objects.equals(this.extraFields, ((BundleContentsComponentExtender) that).extraFields);
+    }
+
+    @Override
+    public List<ItemStack> itematic$stacks() {
+        return this.stacks;
+    }
+
+    @Override
+    public BundleContentsComponentExtraFields itematic$extraFields() {
+        return this.extraFields;
+    }
+
+    @Override
+    public void itematic$setExtraFields(BundleContentsComponentExtraFields extraFields) {
+        this.extraFields = extraFields;
+    }
+
+    @Override
+    public void itematic$calculateOccupancy() {
+        Fraction occupancy = Fraction.ZERO;
+        var rules = this.extraFields.rules();
+        for (ItemStack stack : this.stacks) {
+            occupancy = occupancy.add(rules.occupancy(stack)
+                .multiplyBy(Fraction.getFraction(stack.getCount(), 1)));
+        }
+        this.occupancy = occupancy;
+    }
+
+    @Unique
+    private static BundleContentsComponent create(List<ItemStack> stacks) {
+        return BundleContentsComponentUtil.create(BundleContentsComponentExtraFields.DEFAULT, stacks);
+    }
+
     @Mixin(BundleContentsComponent.Builder.class)
     public static class BuilderExtender implements BundleContentsComponentBuilderAccess {
         @Shadow
@@ -33,6 +157,14 @@ public class BundleContentsComponentExtender {
         @Unique
         private ItemHolderRules rules;
 
+        @Inject(
+            method = "<init>",
+            at = @At("TAIL")
+        )
+        private void setRules(BundleContentsComponent base, CallbackInfo info) {
+            this.rules = base.itematic$extraFields().rules();
+        }
+
         @Redirect(
             method = "getMaxAllowed",
             at = @At(
@@ -44,6 +176,17 @@ public class BundleContentsComponentExtender {
         )
         private Fraction getCapacity() {
             return this.capacity;
+        }
+
+        @Inject(
+            method = "getMaxAllowed",
+            at = @At("HEAD"),
+            cancellable = true
+        )
+        private void checkCanOccupy(ItemStack stack, CallbackInfoReturnable<Integer> info) {
+            if (!this.rules.canOccupy(stack)) {
+                info.setReturnValue(0);
+            }
         }
 
         @Redirect(
@@ -93,14 +236,18 @@ public class BundleContentsComponentExtender {
             this.stacks.addFirst(stack.split(countToAdd));
         }
 
-        @Override
-        public void itematic$setCapacity(int capacity) {
-            this.capacity = Fraction.getFraction(capacity, Item.DEFAULT_MAX_COUNT);
+        @ModifyReturnValue(
+            method = "build",
+            at = @At("TAIL")
+        )
+        private BundleContentsComponent setExtraFields(BundleContentsComponent original) {
+            original.itematic$setExtraFields(new BundleContentsComponentExtraFields(this.rules));
+            return original;
         }
 
         @Override
-        public void itematic$setRules(ItemHolderRules rules) {
-            this.rules = rules;
+        public void itematic$setCapacity(int capacity) {
+            this.capacity = Fraction.getFraction(capacity, Item.DEFAULT_MAX_COUNT);
         }
     }
 }

--- a/src/main/java/net/errorcraft/itematic/mixin/component/type/BundleContentsComponentExtender.java
+++ b/src/main/java/net/errorcraft/itematic/mixin/component/type/BundleContentsComponentExtender.java
@@ -246,8 +246,8 @@ public class BundleContentsComponentExtender implements BundleContentsComponentA
         }
 
         @Override
-        public void itematic$setCapacity(int capacity) {
-            this.capacity = Fraction.getFraction(capacity, Item.DEFAULT_MAX_COUNT);
+        public void itematic$setCapacity(Fraction capacity) {
+            this.capacity = capacity;
         }
     }
 }

--- a/src/main/java/net/errorcraft/itematic/mixin/predicate/item/ItemPredicateExtender.java
+++ b/src/main/java/net/errorcraft/itematic/mixin/predicate/item/ItemPredicateExtender.java
@@ -1,0 +1,113 @@
+package net.errorcraft.itematic.mixin.predicate.item;
+
+import com.llamalad7.mixinextras.injector.ModifyReturnValue;
+import com.mojang.datafixers.kinds.App;
+import com.mojang.datafixers.util.Pair;
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+import net.errorcraft.itematic.access.predicate.item.ItemPredicateAccess;
+import net.errorcraft.itematic.access.predicate.item.ItemPredicateBuilderAccess;
+import net.errorcraft.itematic.item.component.ItemComponentType;
+import net.errorcraft.itematic.predicate.item.ItemPredicateExtraFields;
+import net.minecraft.component.DataComponentType;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraft.predicate.item.ItemPredicate;
+import net.minecraft.registry.entry.RegistryEntryList;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Function;
+
+@Mixin(ItemPredicate.class)
+public class ItemPredicateExtender implements ItemPredicateAccess {
+    @Unique
+    private ItemPredicateExtraFields extraFields;
+
+    @Redirect(
+        method = "<clinit>",
+        at = @At(
+            value = "INVOKE",
+            target = "Lcom/mojang/serialization/codecs/RecordCodecBuilder;create(Ljava/util/function/Function;)Lcom/mojang/serialization/Codec;",
+            remap = false
+        )
+    )
+    private static Codec<ItemPredicate> createCodecAddExtraFields(Function<RecordCodecBuilder.Instance<ItemPredicate>, ? extends App<RecordCodecBuilder.Mu<ItemPredicate>, ItemPredicate>> builder) {
+        return RecordCodecBuilder.mapCodec(builder).dependent(
+            ItemPredicateExtraFields.CODEC,
+            itemPredicate -> Pair.of(
+                ((ItemPredicateExtender)(Object) itemPredicate).extraFields,
+                ItemPredicateExtraFields.CODEC
+            ),
+            (itemPredicate, extraFields) -> {
+                ((ItemPredicateExtender)(Object) itemPredicate).extraFields = extraFields;
+                return itemPredicate;
+            })
+            .codec();
+    }
+
+    @ModifyReturnValue(
+        method = "test(Lnet/minecraft/item/ItemStack;)Z",
+        at = @At("TAIL")
+    )
+    private boolean testExtraFields(boolean original, ItemStack stack) {
+        return this.extraFields.testExtraFields(stack);
+    }
+
+    @Override
+    public ItemPredicateExtraFields itematic$extraFields() {
+        return this.extraFields;
+    }
+
+    @Override
+    public void itematic$setExtraFields(ItemPredicateExtraFields extraFields) {
+        this.extraFields = extraFields;
+    }
+
+    @Mixin(ItemPredicate.Builder.class)
+    public static class BuilderExtender implements ItemPredicateBuilderAccess {
+        @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
+        @Shadow
+        private Optional<RegistryEntryList<Item>> item;
+
+        @Unique
+        private final Set<ItemComponentType<?>> behavior = new HashSet<>();
+
+        @Unique
+        private final Set<DataComponentType<?>> dataComponents = new HashSet<>();
+
+        @ModifyReturnValue(
+            method = "build",
+            at = @At("TAIL")
+        )
+        private ItemPredicate setExtraFields(ItemPredicate original) {
+            ((ItemPredicateAccess)(Object) original).itematic$setExtraFields(ItemPredicateExtraFields.of(this.behavior, this.dataComponents));
+            return original;
+        }
+
+        @Override
+        public ItemPredicate.Builder itematic$items(RegistryEntryList<Item> items) {
+            this.item = Optional.of(items);
+            return (ItemPredicate.Builder)(Object) this;
+        }
+
+        @Override
+        public ItemPredicate.Builder itematic$behavior(ItemComponentType<?>... behavior) {
+            this.behavior.addAll(List.of(behavior));
+            return (ItemPredicate.Builder)(Object) this;
+        }
+
+        @Override
+        public ItemPredicate.Builder itematic$dataComponents(DataComponentType<?>... dataComponents) {
+            this.dataComponents.addAll(List.of(dataComponents));
+            return (ItemPredicate.Builder)(Object) this;
+        }
+    }
+}

--- a/src/main/java/net/errorcraft/itematic/network/codec/PacketCodecUtil.java
+++ b/src/main/java/net/errorcraft/itematic/network/codec/PacketCodecUtil.java
@@ -3,14 +3,24 @@ package net.errorcraft.itematic.network.codec;
 import com.mojang.datafixers.util.Function4;
 import io.netty.buffer.ByteBuf;
 import net.minecraft.network.codec.PacketCodec;
+import net.minecraft.network.codec.PacketCodecs;
 import net.minecraft.registry.Registry;
 import net.minecraft.registry.RegistryKey;
 import net.minecraft.registry.tag.TagKey;
 import net.minecraft.util.Identifier;
+import org.apache.commons.lang3.math.Fraction;
 
+import java.util.HashSet;
+import java.util.Set;
 import java.util.function.Function;
 
 public class PacketCodecUtil {
+    public static final PacketCodec<ByteBuf, Fraction> FRACTION = PacketCodec.tuple(
+        PacketCodecs.VAR_INT, Fraction::getNumerator,
+        PacketCodecs.VAR_INT, Fraction::getDenominator,
+        Fraction::getFraction
+    );
+
     private PacketCodecUtil() {}
 
     public static <B, C, T1, T2, T3, T4> PacketCodec<B, C> tuple(
@@ -42,5 +52,9 @@ public class PacketCodecUtil {
 
     public static <T> PacketCodec<ByteBuf, TagKey<T>> tag(RegistryKey<? extends Registry<T>> registry) {
         return Identifier.PACKET_CODEC.xmap(id -> TagKey.of(registry, id), TagKey::id);
+    }
+
+    public static <B extends ByteBuf, T> PacketCodec<B, Set<T>> set(PacketCodec<B, T> packetCodec) {
+        return PacketCodecs.collection(HashSet::new, packetCodec);
     }
 }

--- a/src/main/java/net/errorcraft/itematic/predicate/item/ItemPredicateExtraFields.java
+++ b/src/main/java/net/errorcraft/itematic/predicate/item/ItemPredicateExtraFields.java
@@ -1,0 +1,69 @@
+package net.errorcraft.itematic.predicate.item;
+
+import com.mojang.serialization.MapCodec;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+import net.errorcraft.itematic.item.component.ItemComponentType;
+import net.errorcraft.itematic.network.codec.PacketCodecUtil;
+import net.errorcraft.itematic.registry.ItematicRegistries;
+import net.errorcraft.itematic.registry.ItematicRegistryKeys;
+import net.errorcraft.itematic.serialization.ItematicCodecs;
+import net.minecraft.component.DataComponentType;
+import net.minecraft.item.ItemStack;
+import net.minecraft.network.RegistryByteBuf;
+import net.minecraft.network.codec.PacketCodec;
+import net.minecraft.network.codec.PacketCodecs;
+import net.minecraft.registry.Registries;
+import net.minecraft.registry.RegistryKeys;
+
+import java.util.Optional;
+import java.util.Set;
+
+public record ItemPredicateExtraFields(Optional<Set<ItemComponentType<?>>> behavior, Optional<Set<DataComponentType<?>>> dataComponents) {
+    public static final MapCodec<ItemPredicateExtraFields> CODEC = RecordCodecBuilder.mapCodec(instance -> instance.group(
+        ItematicCodecs.setCodec(ItematicRegistries.ITEM_COMPONENT_TYPE.getCodec()).optionalFieldOf("behavior").forGetter(ItemPredicateExtraFields::behavior),
+        ItematicCodecs.setCodec(Registries.DATA_COMPONENT_TYPE.getCodec()).optionalFieldOf("data_components").forGetter(ItemPredicateExtraFields::dataComponents)
+    ).apply(instance, ItemPredicateExtraFields::new));
+    public static final PacketCodec<RegistryByteBuf, ItemPredicateExtraFields> PACKET_CODEC = PacketCodec.tuple(
+        PacketCodecs.registryValue(ItematicRegistryKeys.ITEM_COMPONENT_TYPE).collect(PacketCodecUtil::set).collect(PacketCodecs::optional), ItemPredicateExtraFields::behavior,
+        PacketCodecs.registryValue(RegistryKeys.DATA_COMPONENT_TYPE).collect(PacketCodecUtil::set).collect(PacketCodecs::optional), ItemPredicateExtraFields::dataComponents,
+        ItemPredicateExtraFields::new
+    );
+
+    public static ItemPredicateExtraFields of(Set<ItemComponentType<?>> behavior, Set<DataComponentType<?>> dataComponents) {
+        return new ItemPredicateExtraFields(
+            behavior.isEmpty() ? Optional.empty() : Optional.of(behavior),
+            dataComponents.isEmpty() ? Optional.empty() : Optional.of(dataComponents)
+        );
+    }
+
+    public boolean testExtraFields(ItemStack stack) {
+        if (!this.testBehavior(stack)) {
+            return false;
+        }
+        return this.testDataComponents(stack);
+    }
+
+    private boolean testBehavior(ItemStack stack) {
+        if (this.behavior.isEmpty()) {
+            return true;
+        }
+        for (ItemComponentType<?> type : this.behavior.get()) {
+            if (!stack.itematic$hasComponent(type)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private boolean testDataComponents(ItemStack stack) {
+        if (this.dataComponents.isEmpty()) {
+            return true;
+        }
+        for (DataComponentType<?> type : this.dataComponents.get()) {
+            if (!stack.contains(type)) {
+                return false;
+            }
+        }
+        return true;
+    }
+}

--- a/src/main/java/net/errorcraft/itematic/predicate/item/ItemPredicateUtil.java
+++ b/src/main/java/net/errorcraft/itematic/predicate/item/ItemPredicateUtil.java
@@ -1,7 +1,9 @@
 package net.errorcraft.itematic.predicate.item;
 
 import io.netty.buffer.ByteBuf;
+import net.errorcraft.itematic.access.predicate.item.ItemPredicateAccess;
 import net.errorcraft.itematic.mixin.predicate.NumberRangeAccessor;
+import net.minecraft.item.Item;
 import net.minecraft.network.RegistryByteBuf;
 import net.minecraft.network.codec.PacketCodec;
 import net.minecraft.network.codec.PacketCodecs;
@@ -10,6 +12,10 @@ import net.minecraft.predicate.NumberRange;
 import net.minecraft.predicate.item.ItemPredicate;
 import net.minecraft.predicate.item.ItemSubPredicate;
 import net.minecraft.registry.RegistryKeys;
+import net.minecraft.registry.entry.RegistryEntryList;
+
+import java.util.Map;
+import java.util.Optional;
 
 public class ItemPredicateUtil {
     private static final PacketCodec<ByteBuf, NumberRange.IntRange> INTEGER_RANGE_PACKET_CODEC = PacketCodec.tuple(
@@ -22,8 +28,16 @@ public class ItemPredicateUtil {
         INTEGER_RANGE_PACKET_CODEC, ItemPredicate::count,
         ComponentPredicate.PACKET_CODEC, ItemPredicate::components,
         PacketCodecs.registryCodec(ItemSubPredicate.PREDICATES_MAP_CODEC), ItemPredicate::subPredicates,
-        ItemPredicate::new
+        ItemPredicateExtraFields.PACKET_CODEC, itemPredicate -> ((ItemPredicateAccess)(Object) itemPredicate).itematic$extraFields(),
+        ItemPredicateUtil::create
     );
+
+    @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
+    private static ItemPredicate create(Optional<RegistryEntryList<Item>> items, NumberRange.IntRange count, ComponentPredicate components, Map<ItemSubPredicate.Type<?>, ItemSubPredicate> subPredicates, ItemPredicateExtraFields extraFields) {
+        ItemPredicate predicate = new ItemPredicate(items, count, components, subPredicates);
+        ((ItemPredicateAccess)(Object) predicate).itematic$setExtraFields(extraFields);
+        return predicate;
+    }
 
     private ItemPredicateUtil() {}
 }

--- a/src/main/java/net/errorcraft/itematic/registry/ItematicRegistries.java
+++ b/src/main/java/net/errorcraft/itematic/registry/ItematicRegistries.java
@@ -6,6 +6,8 @@ import net.errorcraft.itematic.item.component.ItemComponentType;
 import net.errorcraft.itematic.item.component.ItemComponentTypes;
 import net.errorcraft.itematic.item.event.ItemEvent;
 import net.errorcraft.itematic.item.event.ItemEvents;
+import net.errorcraft.itematic.item.holder.rule.ItemHolderRuleType;
+import net.errorcraft.itematic.item.holder.rule.ItemHolderRuleTypes;
 import net.errorcraft.itematic.item.model.override.ModelOverride;
 import net.errorcraft.itematic.item.model.override.ModelOverrides;
 import net.errorcraft.itematic.item.placement.block.picker.BlockPickerType;
@@ -37,6 +39,7 @@ public class ItematicRegistries {
     public static final Registry<BlockPickerType<?>> BLOCK_PICKER_TYPE = RegistriesAccessor.create(ItematicRegistryKeys.BLOCK_PICKER_TYPE, r -> BlockPickerTypes.SIMPLE);
     public static final Registry<TradeModifierType<?>> TRADE_MODIFIER_TYPE = RegistriesAccessor.create(ItematicRegistryKeys.TRADE_MODIFIER_TYPE, r -> TradeModifierTypes.ENCHANT_WITH_LEVELS);
     public static final Registry<IntegerProviderType<?>> INTEGER_PROVIDER_TYPE = RegistriesAccessor.create(ItematicRegistryKeys.INTEGER_PROVIDER_TYPE, r -> IntegerProviderTypes.CONSTANT);
+    public static final Registry<ItemHolderRuleType<?>> ITEM_HOLDER_RULE_TYPE = RegistriesAccessor.create(ItematicRegistryKeys.ITEM_HOLDER_RULE_TYPE, r -> ItemHolderRuleTypes.REJECT);
 
     private ItematicRegistries() {}
 }

--- a/src/main/java/net/errorcraft/itematic/registry/ItematicRegistryKeys.java
+++ b/src/main/java/net/errorcraft/itematic/registry/ItematicRegistryKeys.java
@@ -6,6 +6,7 @@ import net.errorcraft.itematic.item.component.ItemComponentType;
 import net.errorcraft.itematic.item.dispense.behavior.DispenseBehavior;
 import net.errorcraft.itematic.item.event.ItemEvent;
 import net.errorcraft.itematic.item.group.entry.provider.ItemGroupEntryProvider;
+import net.errorcraft.itematic.item.holder.rule.ItemHolderRuleType;
 import net.errorcraft.itematic.item.model.override.ModelOverride;
 import net.errorcraft.itematic.item.placement.block.picker.BlockPickerType;
 import net.errorcraft.itematic.item.pointer.Pointer;
@@ -39,6 +40,7 @@ public class ItematicRegistryKeys {
     public static final RegistryKey<Registry<BlockPickerType<?>>> BLOCK_PICKER_TYPE = RegistryKey.ofRegistry(new Identifier("block_picker_type"));
     public static final RegistryKey<Registry<TradeModifierType<?>>> TRADE_MODIFIER_TYPE = RegistryKey.ofRegistry(new Identifier("trade_modifier_type"));
     public static final RegistryKey<Registry<IntegerProviderType<?>>> INTEGER_PROVIDER_TYPE = RegistryKey.ofRegistry(new Identifier("integer_provider_type"));
+    public static final RegistryKey<Registry<ItemHolderRuleType<?>>> ITEM_HOLDER_RULE_TYPE = RegistryKey.ofRegistry(new Identifier("item_holder_rule_type"));
 
     private ItematicRegistryKeys() {}
 }

--- a/src/main/java/net/errorcraft/itematic/serialization/ItematicCodecs.java
+++ b/src/main/java/net/errorcraft/itematic/serialization/ItematicCodecs.java
@@ -58,6 +58,18 @@ public class ItematicCodecs {
         return CodecsAccessor.rangedFloat(0.0f, maxInclusive, value -> "Value must be positive and at most " + maxInclusive + ": " + value);
     }
 
+    public static Codec<Fraction> positiveFraction(int maxInclusive) {
+        if (maxInclusive <= 0) {
+            throw new IllegalArgumentException("maxInclusive must be positive, got " + maxInclusive + " instead");
+        }
+        return POSITIVE_FRACTION.validate(fraction -> {
+            if (fraction.intValue() > maxInclusive) {
+                return DataResult.error(() -> "Fraction must be at most " + maxInclusive);
+            }
+            return DataResult.success(fraction);
+        });
+    }
+
     private static class SetCodec<E> implements Codec<Set<E>> {
         private final Codec<List<E>> listCodec;
 

--- a/src/main/java/net/errorcraft/itematic/serialization/ItematicCodecs.java
+++ b/src/main/java/net/errorcraft/itematic/serialization/ItematicCodecs.java
@@ -4,7 +4,10 @@ import com.mojang.datafixers.util.Pair;
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.DataResult;
 import com.mojang.serialization.DynamicOps;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
 import net.errorcraft.itematic.mixin.util.dynamic.CodecsAccessor;
+import net.minecraft.util.dynamic.Codecs;
+import org.apache.commons.lang3.math.Fraction;
 
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -25,6 +28,10 @@ public class ItematicCodecs {
         }
         return DataResult.error(() -> "Value must be non-negative: " + value);
     });
+    public static final Codec<Fraction> POSITIVE_FRACTION = RecordCodecBuilder.create(instance -> instance.group(
+        Codecs.POSITIVE_INT.fieldOf("numerator").forGetter(Fraction::getNumerator),
+        Codecs.POSITIVE_INT.fieldOf("denominator").forGetter(Fraction::getDenominator)
+    ).apply(instance, Fraction::getFraction));
 
     private ItematicCodecs() {}
 

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -159,6 +159,9 @@
       "net/minecraft/class_9085": [
         "net/errorcraft/itematic/access/client/render/entity/feature/WolfArmorFeatureRendererAccess"
       ],
+      "net/minecraft/class_9276": [
+        "net/errorcraft/itematic/access/component/type/BundleContentsComponentAccess"
+      ],
       "net/minecraft/class_9276\u0024class_9277": [
         "net/errorcraft/itematic/access/component/type/BundleContentsComponentBuilderAccess"
       ],

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -99,6 +99,9 @@
       "net/minecraft/class_2048\u0024class_2049": [
         "net/errorcraft/itematic/access/predicate/EntityPredicateBuilderAccess"
       ],
+      "net/minecraft/class_2073\u0024class_2074": [
+        "net/errorcraft/itematic/access/predicate/item/ItemPredicateBuilderAccess"
+      ],
       "net/minecraft/class_2248": [
         "net/errorcraft/itematic/access/block/BlockAccess"
       ],

--- a/src/main/resources/itematic.mixins.json
+++ b/src/main/resources/itematic.mixins.json
@@ -83,6 +83,7 @@
     "command.argument.ScoreboardCriterionArgumentTypeExtender",
     "component.DataComponentTypesAccessor",
     "component.DataComponentTypesExtender",
+    "component.type.BundleContentsComponentAccessor",
     "component.type.BundleContentsComponentExtender",
     "component.type.BundleContentsComponentExtender$BuilderExtender",
     "component.type.ChargedProjectilesComponentExtender",

--- a/src/main/resources/itematic.mixins.json
+++ b/src/main/resources/itematic.mixins.json
@@ -306,6 +306,8 @@
     "predicate.entity.EntityPredicateExtender",
     "predicate.entity.EntityPredicateExtender$BuilderExtender",
     "predicate.entity.PlayerPredicateExtender$StatMatcherExtender",
+    "predicate.item.ItemPredicateExtender",
+    "predicate.item.ItemPredicateExtender$BuilderExtender",
     "recipe.ArmorDyeRecipeExtender",
     "recipe.BannerDuplicateRecipeExtender",
     "recipe.BlastingRecipeExtender",


### PR DESCRIPTION
No longer hardcodes the item holder add behaviour.

# Changes
## Behaviour Components
- Expanded `minecraft:item_holder`.
	- Added the `rules` field.
		- Its value is a list of item holder rules and determines whether an item stack can be added or not and decides how much room it takes.
		- See the item holder rules section for more information.
		- If no rule is picked, the inverse of its maximum stack size will be used instead.
		- This value can be changed for individual item stacks in the new `rules` field in the `minecraft:bundle_contents` data component.
		- Example:
			```json
			[
			  {
			    "type": "minecraft:reject",
			    "condition": {
			      "items": "#minecraft:banned_bundle_items"
			    }
			  },
			  {
			    "type": "minecraft:fraction_with_occupancy_held_items",
			    "condition": {
			      "behavior": [
			        "minecraft:item_holder"
			      ]
			    },
			    "fraction": {
			      "denominator": 4,
			      "numerator": 1
			    }
			  },
			  {
			    "type": "minecraft:fraction",
			    "condition": {
			      "data_components": [
			        "minecraft:bees"
			      ]
			    },
			    "fraction": {
			      "denominator": 1,
			      "numerator": 1
			    }
			  }
			]
			```
	- Changed the `capacity` field.
		- Its value is now a positive fraction that is capped at a value of 100 and determines how many 'full stacks' an item holder can hold.
			- See the extras section for more information on fractions.
		- This value can be changed for individual item stacks in the new `minecraft:item_holder_capacity` data component.
		- Example:
			```json
			{
			  "denominator": 4,
			  "numerator": 1
			}
			```

## Data Components
- Added the `minecraft:item_holder_capacity` data component.
	- This data component is specified and used by the minecraft:item_holder behaviour component.
	- Its value is a positive fraction that is capped at a value of 100 and determines how many 'full stacks' an item holder can hold.
		- See the extras section for more information on fractions and its format.
		- If this data component is removed, the item holder behaviour will no longer work.
		- Examples:
			- `{"numerator": 1, "denominator": 1}` (`1/1`) would be able to hold 64 item stacks of items stackable to 64.
			- `{"numerator": 2, "denominator": 1}` (`2/1`) would be able to hold 128 item stacks of items stackable to 64.
			- `{"numerator": 1, "denominator": 2}` (`1/2`) would be able to hold 32 item stacks of items stackable to 64.
- Changed the `minecraft:bundle_contents` data component.
	- Now has an expanded form to make room for the new item holder rules.
		- This form will always be used when saved.
		- Fields:
			- `rules`: A list of rules to apply to added item stacks. See the item holder rules section for more information.
			- `items`: The same list of item stacks as before.

## Item Holder Rules
- Determines whether an item stack can be added to an item holder or not and decides how much room it takes.
- Format: A map with fields determined by the type in the `type` field, as well as an optional `condition` field that is an item predicate.
- Example:
	```json
	{
	  "type": "minecraft:reject",
	  "condition": {
	    "items": "#minecraft:banned_bundle_items"
	  }
	}
	```

### `minecraft:fraction`
- Uses the specified fraction as its occupancy.
- Fields:
	- `fraction`: A positive fraction that is capped at a value of 100. The fraction to use as its occupancy.
### `minecraft:fraction_with_occupancy_held_items`
- Uses the occupancy of the item stack's item holder item stacks with a penalty added on top of it.
- If the item stack does not have the `minecraft:item_holder` behaviour component or doesn't have the `minecraft:bundle_contents` data component, it will only add the penalty.
- Fields:
	- `fraction`: A positive fraction that is capped at a value of 100. The penalty to add to the occupancy.
### `minecraft:reject`
- Prevents the item stack from being added to the item holder altogether.
- Has no additional fields.

## Extras
### Fractions
- A way of representing fractions to keep accuracy of numbers where this is necessary.
- Fields:
	- `numerator`: An integer used for the numerator of the fraction.
	- `denominator`: An integer used for the denominator of the fraction.
- Fails to parse the denominator is 0.
- Example:
	```json
	{
	  "denominator": 4,
	  "numerator": 1
	}
	```
### Item Predicates
- Added the following fields:
	- `behavior`: An optional list of behaviour component types. Checks whether the item has the specified item behaviour components.
	- `data_components`: An optional list of data component types. Checks whether the item stack has the specified data components.
		- Note: this field is temporary and will be removed sometime in 1.21 in favour of component predicates!
