### PR TITLE
Expand smashing weapons

### DIFF
--- a/src/main/generated/data/minecraft/item/mace.json
+++ b/src/main/generated/data/minecraft/item/mace.json
@@ -28,6 +28,7 @@
             "on_ground_large_fall_distance": "minecraft:item.mace.smash_ground_heavy",
             "on_ground_small_fall_distance": "minecraft:item.mace.smash_ground"
           },
+          "knockback_power": 0.699999988079071,
           "smash_attack_fall_distance": 1.5
         }
       }

--- a/src/main/generated/data/minecraft/item/mace.json
+++ b/src/main/generated/data/minecraft/item/mace.json
@@ -21,7 +21,15 @@
       },
       "attack_speed": 0.15,
       "types": {
-        "minecraft:smashing": {}
+        "minecraft:smashing": {
+          "heavy_smash_attack_fall_distance": 5.0,
+          "hit_sounds": {
+            "in_air": "minecraft:item.mace.smash_air",
+            "on_ground_large_fall_distance": "minecraft:item.mace.smash_ground_heavy",
+            "on_ground_small_fall_distance": "minecraft:item.mace.smash_ground"
+          },
+          "smash_attack_fall_distance": 1.5
+        }
       }
     }
   },

--- a/src/main/java/net/errorcraft/itematic/component/ItematicDataComponentTypes.java
+++ b/src/main/java/net/errorcraft/itematic/component/ItematicDataComponentTypes.java
@@ -33,6 +33,7 @@ public class ItematicDataComponentTypes {
     public static final ComponentType<ChargeableShooterMethod.ChargedPowerRules> SHOOTER_CHARGED_POWER_RULES = DataComponentTypesAccessor.register("shooter_charged_power_rules", builder -> builder.codec(ChargeableShooterMethod.ChargedPowerRules.CODEC).packetCodec(ChargeableShooterMethod.ChargedPowerRules.PACKET_CODEC));
     public static final ComponentType<RegistryEntry<SoundEvent>> SHOOTER_SHOOT_SOUND = DataComponentTypesAccessor.register("shooter_shoot_sound", builder -> builder.codec(SoundEvent.ENTRY_CODEC).packetCodec(SoundEvent.ENTRY_PACKET_CODEC));
     public static final ComponentType<GliderDataComponent> GLIDER = DataComponentTypesAccessor.register("glider", builder -> builder.codec(GliderDataComponent.CODEC).packetCodec(GliderDataComponent.PACKET_CODEC).cache());
+    public static final ComponentType<SmashingWeaponDataComponent> SMASHING_WEAPON = DataComponentTypesAccessor.register("smashing_weapon", builder -> builder.codec(SmashingWeaponDataComponent.CODEC).packetCodec(SmashingWeaponDataComponent.PACKET_CODEC).cache());
 
     private ItematicDataComponentTypes() {}
 

--- a/src/main/java/net/errorcraft/itematic/component/type/SmashingWeaponDataComponent.java
+++ b/src/main/java/net/errorcraft/itematic/component/type/SmashingWeaponDataComponent.java
@@ -11,21 +11,23 @@ import net.minecraft.network.codec.PacketCodecs;
 import net.minecraft.registry.entry.RegistryEntry;
 import net.minecraft.sound.SoundEvent;
 
-public record SmashingWeaponDataComponent(HitSounds hitSounds, double smashAttackFallDistance, double heavySmashAttackFallDistance) {
+public record SmashingWeaponDataComponent(HitSounds hitSounds, double smashAttackFallDistance, double heavySmashAttackFallDistance, double knockbackPower) {
     public static final Codec<SmashingWeaponDataComponent> CODEC = RecordCodecBuilder.create(instance -> instance.group(
         HitSounds.CODEC.fieldOf("hit_sounds").forGetter(SmashingWeaponDataComponent::hitSounds),
         ItematicCodecs.POSITIVE_DOUBLE.fieldOf("smash_attack_fall_distance").forGetter(SmashingWeaponDataComponent::smashAttackFallDistance),
-        ItematicCodecs.POSITIVE_DOUBLE.fieldOf("heavy_smash_attack_fall_distance").forGetter(SmashingWeaponDataComponent::heavySmashAttackFallDistance)
+        ItematicCodecs.POSITIVE_DOUBLE.fieldOf("heavy_smash_attack_fall_distance").forGetter(SmashingWeaponDataComponent::heavySmashAttackFallDistance),
+        ItematicCodecs.POSITIVE_DOUBLE.fieldOf("knockback_power").forGetter(SmashingWeaponDataComponent::knockbackPower)
     ).apply(instance, SmashingWeaponDataComponent::new));
     public static final PacketCodec<RegistryByteBuf, SmashingWeaponDataComponent> PACKET_CODEC = PacketCodec.tuple(
         HitSounds.PACKET_CODEC, SmashingWeaponDataComponent::hitSounds,
         PacketCodecs.DOUBLE, SmashingWeaponDataComponent::smashAttackFallDistance,
         PacketCodecs.DOUBLE, SmashingWeaponDataComponent::heavySmashAttackFallDistance,
+        PacketCodecs.DOUBLE, SmashingWeaponDataComponent::knockbackPower,
         SmashingWeaponDataComponent::new
     );
 
-    public static SmashingWeaponDataComponent of(HitSounds hitSounds, double smashAttackFallDistance, double heavySmashAttackFallDistance) {
-        return new SmashingWeaponDataComponent(hitSounds, smashAttackFallDistance, heavySmashAttackFallDistance);
+    public static SmashingWeaponDataComponent of(HitSounds hitSounds, double smashAttackFallDistance, double heavySmashAttackFallDistance, double knockbackPower) {
+        return new SmashingWeaponDataComponent(hitSounds, smashAttackFallDistance, heavySmashAttackFallDistance, knockbackPower);
     }
 
     public boolean canSmash(LivingEntity attacker) {

--- a/src/main/java/net/errorcraft/itematic/component/type/SmashingWeaponDataComponent.java
+++ b/src/main/java/net/errorcraft/itematic/component/type/SmashingWeaponDataComponent.java
@@ -1,0 +1,60 @@
+package net.errorcraft.itematic.component.type;
+
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+import net.errorcraft.itematic.serialization.ItematicCodecs;
+import net.minecraft.entity.LivingEntity;
+import net.minecraft.entity.damage.DamageSource;
+import net.minecraft.network.RegistryByteBuf;
+import net.minecraft.network.codec.PacketCodec;
+import net.minecraft.network.codec.PacketCodecs;
+import net.minecraft.registry.entry.RegistryEntry;
+import net.minecraft.sound.SoundEvent;
+
+public record SmashingWeaponDataComponent(HitSounds hitSounds, double smashAttackFallDistance, double heavySmashAttackFallDistance) {
+    public static final Codec<SmashingWeaponDataComponent> CODEC = RecordCodecBuilder.create(instance -> instance.group(
+        HitSounds.CODEC.fieldOf("hit_sounds").forGetter(SmashingWeaponDataComponent::hitSounds),
+        ItematicCodecs.POSITIVE_DOUBLE.fieldOf("smash_attack_fall_distance").forGetter(SmashingWeaponDataComponent::smashAttackFallDistance),
+        ItematicCodecs.POSITIVE_DOUBLE.fieldOf("heavy_smash_attack_fall_distance").forGetter(SmashingWeaponDataComponent::heavySmashAttackFallDistance)
+    ).apply(instance, SmashingWeaponDataComponent::new));
+    public static final PacketCodec<RegistryByteBuf, SmashingWeaponDataComponent> PACKET_CODEC = PacketCodec.tuple(
+        HitSounds.PACKET_CODEC, SmashingWeaponDataComponent::hitSounds,
+        PacketCodecs.DOUBLE, SmashingWeaponDataComponent::smashAttackFallDistance,
+        PacketCodecs.DOUBLE, SmashingWeaponDataComponent::heavySmashAttackFallDistance,
+        SmashingWeaponDataComponent::new
+    );
+
+    public static SmashingWeaponDataComponent of(HitSounds hitSounds, double smashAttackFallDistance, double heavySmashAttackFallDistance) {
+        return new SmashingWeaponDataComponent(hitSounds, smashAttackFallDistance, heavySmashAttackFallDistance);
+    }
+
+    public boolean canSmash(LivingEntity attacker) {
+        return attacker.fallDistance > this.smashAttackFallDistance && !attacker.isGliding();
+    }
+
+    public DamageSource damageSource(LivingEntity attacker) {
+        if (this.canSmash(attacker)) {
+            return attacker.getDamageSources().maceSmash(attacker);
+        }
+
+        return null;
+    }
+
+    public record HitSounds(RegistryEntry<SoundEvent> inAir, RegistryEntry<SoundEvent> onGroundSmallFallDistance, RegistryEntry<SoundEvent> onGroundLargeFallDistance) {
+        public static final Codec<HitSounds> CODEC = RecordCodecBuilder.create(instance -> instance.group(
+            SoundEvent.ENTRY_CODEC.fieldOf("in_air").forGetter(HitSounds::inAir),
+            SoundEvent.ENTRY_CODEC.fieldOf("on_ground_small_fall_distance").forGetter(HitSounds::onGroundSmallFallDistance),
+            SoundEvent.ENTRY_CODEC.fieldOf("on_ground_large_fall_distance").forGetter(HitSounds::onGroundLargeFallDistance)
+        ).apply(instance, HitSounds::new));
+        public static final PacketCodec<RegistryByteBuf, HitSounds> PACKET_CODEC = PacketCodec.tuple(
+            SoundEvent.ENTRY_PACKET_CODEC, HitSounds::inAir,
+            SoundEvent.ENTRY_PACKET_CODEC, HitSounds::onGroundSmallFallDistance,
+            SoundEvent.ENTRY_PACKET_CODEC, HitSounds::onGroundLargeFallDistance,
+            HitSounds::new
+        );
+
+        public static HitSounds of(RegistryEntry<SoundEvent> inAir, RegistryEntry<SoundEvent> onGroundSmallFallDistance, RegistryEntry<SoundEvent> onGroundLargeFallDistance) {
+            return new HitSounds(inAir, onGroundSmallFallDistance, onGroundLargeFallDistance);
+        }
+    }
+}

--- a/src/main/java/net/errorcraft/itematic/item/ItemUtil.java
+++ b/src/main/java/net/errorcraft/itematic/item/ItemUtil.java
@@ -5,6 +5,7 @@ import com.mojang.serialization.codecs.RecordCodecBuilder;
 import net.errorcraft.itematic.block.BlockKeys;
 import net.errorcraft.itematic.block.ItematicBlockTags;
 import net.errorcraft.itematic.component.type.ItemDamageRulesDataComponent;
+import net.errorcraft.itematic.component.type.SmashingWeaponDataComponent;
 import net.errorcraft.itematic.entity.EntityTypeKeys;
 import net.errorcraft.itematic.entity.effect.StatusEffectKeys;
 import net.errorcraft.itematic.entity.spawn.EntitySpawner;
@@ -31,6 +32,7 @@ import net.errorcraft.itematic.loot.function.SplitItemModifier;
 import net.errorcraft.itematic.loot.predicate.SideCheckPredicate;
 import net.errorcraft.itematic.mixin.item.BrushItemAccessor;
 import net.errorcraft.itematic.mixin.item.CrossbowItemAccessor;
+import net.errorcraft.itematic.mixin.item.MaceItemAccessor;
 import net.errorcraft.itematic.potion.PotionKeys;
 import net.errorcraft.itematic.registry.ItematicRegistryKeys;
 import net.errorcraft.itematic.sound.SoundEventKeys;
@@ -6143,7 +6145,15 @@ public class ItemUtil {
                     .with(DamageableItemComponent.of(500))
                     .with(ToolItemComponent.builder(2).build())
                     .with(WeaponItemComponent.builder(1, 5.0d, 0.15d)
-                        .type(MeleeWeaponComponents.SMASHING, SmashingMeleeWeapon.INSTANCE)
+                        .type(MeleeWeaponComponents.SMASHING, SmashingMeleeWeapon.of(SmashingWeaponDataComponent.of(
+                            SmashingWeaponDataComponent.HitSounds.of(
+                                this.soundEvents.getOrThrow(SoundEventKeys.MACE_SMASH_AIR),
+                                this.soundEvents.getOrThrow(SoundEventKeys.MACE_SMASH_GROUND),
+                                this.soundEvents.getOrThrow(SoundEventKeys.MACE_SMASH_GROUND_HEAVY)
+                            ),
+                            MaceItem.MINING_SPEED_MULTIPLIER,
+                            MaceItemAccessor.heavySmashAttackFallDistance()
+                        )))
                         .build())
                     .with(EnchantableItemComponent.of(15))
                     .with(RepairableItemComponent.of(RegistryEntryList.of(

--- a/src/main/java/net/errorcraft/itematic/item/ItemUtil.java
+++ b/src/main/java/net/errorcraft/itematic/item/ItemUtil.java
@@ -6152,7 +6152,8 @@ public class ItemUtil {
                                 this.soundEvents.getOrThrow(SoundEventKeys.MACE_SMASH_GROUND_HEAVY)
                             ),
                             MaceItem.MINING_SPEED_MULTIPLIER,
-                            MaceItemAccessor.heavySmashAttackFallDistance()
+                            MaceItemAccessor.heavySmashAttackFallDistance(),
+                            MaceItemAccessor.knockbackPower()
                         )))
                         .build())
                     .with(EnchantableItemComponent.of(15))

--- a/src/main/java/net/errorcraft/itematic/item/component/components/WeaponItemComponent.java
+++ b/src/main/java/net/errorcraft/itematic/item/component/components/WeaponItemComponent.java
@@ -23,7 +23,9 @@ import net.minecraft.component.DataComponentTypes;
 import net.minecraft.component.type.AttackRangeComponent;
 import net.minecraft.component.type.SwingAnimationComponent;
 import net.minecraft.component.type.WeaponComponent;
+import net.minecraft.entity.Entity;
 import net.minecraft.entity.LivingEntity;
+import net.minecraft.entity.damage.DamageSource;
 import net.minecraft.entity.damage.DamageType;
 import net.minecraft.item.ItemStack;
 import net.minecraft.loot.context.LootContextParameters;
@@ -112,6 +114,31 @@ public record WeaponItemComponent(int itemDamagePerAttack, float disableBlocking
     @Override
     public ComponentMap getComponents() {
         return this.types;
+    }
+
+    public float bonusAttackDamage(Entity target, float baseAttackDamage, DamageSource damageSource) {
+        SmashingMeleeWeapon smashing = this.types.get(MeleeWeaponComponents.SMASHING);
+        if (smashing != null) {
+            return smashing.bonusAttackDamage(target, baseAttackDamage, damageSource);
+        }
+
+        return 0.0f;
+    }
+
+    public void postDamageEntity(ItemStack stack, LivingEntity target, LivingEntity attacker) {
+        SmashingMeleeWeapon smashing = this.types.get(MeleeWeaponComponents.SMASHING);
+        if (smashing != null) {
+            smashing.postDamageEntity(stack, target, attacker);
+        }
+    }
+
+    public DamageSource damageSource(ItemStack stack, LivingEntity attacker) {
+        SmashingMeleeWeapon smashing = this.types.get(MeleeWeaponComponents.SMASHING);
+        if (smashing != null) {
+            return smashing.damageSource(stack, attacker);
+        }
+
+        return null;
     }
 
     public static class Builder {

--- a/src/main/java/net/errorcraft/itematic/item/weapon/melee/component/SmashingMeleeWeapon.java
+++ b/src/main/java/net/errorcraft/itematic/item/weapon/melee/component/SmashingMeleeWeapon.java
@@ -1,20 +1,51 @@
 package net.errorcraft.itematic.item.weapon.melee.component;
 
 import com.mojang.serialization.Codec;
-import com.mojang.serialization.MapCodec;
+import net.errorcraft.itematic.component.ItematicDataComponentTypes;
+import net.errorcraft.itematic.component.type.SmashingWeaponDataComponent;
+import net.errorcraft.itematic.item.weapon.melee.MeleeWeaponWithDataComponents;
+import net.minecraft.component.ComponentMap;
+import net.minecraft.entity.Entity;
 import net.minecraft.entity.LivingEntity;
+import net.minecraft.entity.damage.DamageSource;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.MaceItem;
 
-public class SmashingMeleeWeapon {
-    public static final SmashingMeleeWeapon INSTANCE = new SmashingMeleeWeapon();
-    public static final Codec<SmashingMeleeWeapon> CODEC = MapCodec.unitCodec(INSTANCE);
+public record SmashingMeleeWeapon(SmashingWeaponDataComponent smashingWeapon) implements MeleeWeaponWithDataComponents {
+    public static final Codec<SmashingMeleeWeapon> CODEC = SmashingWeaponDataComponent.CODEC.xmap(
+        SmashingMeleeWeapon::new,
+        SmashingMeleeWeapon::smashingWeapon
+    );
     private static final MaceItem DUMMY = new MaceItem(new Item.Settings());
 
-    private SmashingMeleeWeapon() {}
+    public static SmashingMeleeWeapon of(SmashingWeaponDataComponent smashingWeapon) {
+        return new SmashingMeleeWeapon(smashingWeapon);
+    }
+
+    @Override
+    public void addComponents(ComponentMap.Builder builder) {
+        builder.add(ItematicDataComponentTypes.SMASHING_WEAPON, this.smashingWeapon);
+    }
 
     public void hit(ItemStack stack, LivingEntity target, LivingEntity attacker) {
         DUMMY.postHit(stack, target, attacker);
+    }
+
+    public float bonusAttackDamage(Entity target, float baseAttackDamage, DamageSource damageSource) {
+        return DUMMY.getBonusAttackDamage(target, baseAttackDamage, damageSource);
+    }
+
+    public void postDamageEntity(ItemStack stack, LivingEntity target, LivingEntity attacker) {
+        DUMMY.postDamageEntity(stack, target, attacker);
+    }
+
+    public DamageSource damageSource(ItemStack stack, LivingEntity attacker) {
+        SmashingWeaponDataComponent smashingWeapon = stack.get(ItematicDataComponentTypes.SMASHING_WEAPON);
+        if (smashingWeapon != null) {
+            return smashingWeapon.damageSource(attacker);
+        }
+
+        return null;
     }
 }

--- a/src/main/java/net/errorcraft/itematic/mixin/item/ItemExtender.java
+++ b/src/main/java/net/errorcraft/itematic/mixin/item/ItemExtender.java
@@ -1,6 +1,7 @@
 package net.errorcraft.itematic.mixin.item;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.llamalad7.mixinextras.injector.ModifyReturnValue;
 import com.mojang.serialization.Codec;
 import net.errorcraft.itematic.access.item.ItemAccess;
 import net.errorcraft.itematic.component.ItematicDataComponentTypes;
@@ -35,6 +36,7 @@ import net.minecraft.entity.Entity;
 import net.minecraft.entity.EquipmentSlot;
 import net.minecraft.entity.ItemEntity;
 import net.minecraft.entity.LivingEntity;
+import net.minecraft.entity.damage.DamageSource;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.inventory.StackReference;
 import net.minecraft.item.Item;
@@ -277,6 +279,15 @@ public abstract class ItemExtender implements ItemAccess, FabricItem {
         tryUpdateItemStack(attacker, Hand.MAIN_HAND, stack, stackExchanger);
     }
 
+    @Inject(
+        method = "postDamageEntity",
+        at = @At("HEAD")
+    )
+    private void postDamageEntityUseItemComponent(ItemStack stack, LivingEntity target, LivingEntity attacker, CallbackInfo info) {
+        this.itematic$getBehavior(ItemComponentTypes.WEAPON)
+            .ifPresent(weapon -> weapon.postDamageEntity(stack, target, attacker));
+    }
+
     /**
      * @author ErrorCraft
      * @reason Uses the ItemComponent implementation for data-driven items.
@@ -420,6 +431,16 @@ public abstract class ItemExtender implements ItemAccess, FabricItem {
 
         cursorStackReference.set(stackExchanger.result());
         return result;
+    }
+
+    @ModifyReturnValue(
+        method = "getBonusAttackDamage",
+        at = @At("TAIL")
+    )
+    private float getBonusAttackDamageUseItemComponent(float original, Entity target, float baseAttackDamage, DamageSource damageSource) {
+        return this.itematic$getBehavior(ItemComponentTypes.WEAPON)
+            .map(weapon -> weapon.bonusAttackDamage(target, baseAttackDamage, damageSource))
+            .orElse(0.0f);
     }
 
     @Inject(

--- a/src/main/java/net/errorcraft/itematic/mixin/item/ItemStackExtender.java
+++ b/src/main/java/net/errorcraft/itematic/mixin/item/ItemStackExtender.java
@@ -28,6 +28,7 @@ import net.minecraft.enchantment.Enchantment;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EquipmentSlot;
 import net.minecraft.entity.LivingEntity;
+import net.minecraft.entity.damage.DamageSource;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.inventory.StackReference;
 import net.minecraft.item.Item;
@@ -671,6 +672,20 @@ public abstract class ItemStackExtender implements ComponentHolder, ItemStackAcc
         if (!this.itematic$hasBehavior(ItemComponentTypes.USEABLE)) {
             info.setReturnValue((ItemStack) (Object) this);
         }
+    }
+
+    @Redirect(
+        method = "method_75224",
+        at = @At(
+            value = "INVOKE",
+            target = "Lnet/minecraft/item/Item;getDamageSource(Lnet/minecraft/entity/LivingEntity;)Lnet/minecraft/entity/damage/DamageSource;"
+        )
+    )
+    @SuppressWarnings("ConstantValue")
+    private DamageSource getDamageSourceUseItemComponent(Item instance, LivingEntity user) {
+        return this.itematic$getBehavior(ItemComponentTypes.WEAPON)
+            .map(weapon -> weapon.damageSource((ItemStack)(Object) this, user))
+            .orElse(null);
     }
 
     /**

--- a/src/main/java/net/errorcraft/itematic/mixin/item/MaceItemAccessor.java
+++ b/src/main/java/net/errorcraft/itematic/mixin/item/MaceItemAccessor.java
@@ -1,0 +1,13 @@
+package net.errorcraft.itematic.mixin.item;
+
+import net.minecraft.item.MaceItem;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+@Mixin(MaceItem.class)
+public interface MaceItemAccessor {
+    @Accessor("HEAVY_SMASH_SOUND_FALL_DISTANCE_THRESHOLD")
+    static float heavySmashAttackFallDistance() {
+        throw new AssertionError();
+    }
+}

--- a/src/main/java/net/errorcraft/itematic/mixin/item/MaceItemAccessor.java
+++ b/src/main/java/net/errorcraft/itematic/mixin/item/MaceItemAccessor.java
@@ -10,4 +10,9 @@ public interface MaceItemAccessor {
     static float heavySmashAttackFallDistance() {
         throw new AssertionError();
     }
+
+    @Accessor("KNOCKBACK_POWER")
+    static float knockbackPower() {
+        throw new AssertionError();
+    }
 }

--- a/src/main/java/net/errorcraft/itematic/mixin/item/MaceItemExtender.java
+++ b/src/main/java/net/errorcraft/itematic/mixin/item/MaceItemExtender.java
@@ -1,0 +1,163 @@
+package net.errorcraft.itematic.mixin.item;
+
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import com.llamalad7.mixinextras.sugar.Share;
+import com.llamalad7.mixinextras.sugar.ref.LocalRef;
+import net.errorcraft.itematic.component.ItematicDataComponentTypes;
+import net.errorcraft.itematic.component.type.SmashingWeaponDataComponent;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.LivingEntity;
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.MaceItem;
+import net.minecraft.sound.SoundEvent;
+import net.minecraft.world.World;
+import org.objectweb.asm.Opcodes;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.*;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import java.util.Objects;
+
+@Mixin(MaceItem.class)
+public class MaceItemExtender {
+    @Unique
+    private static SmashingWeaponDataComponent usedStackSmashingWeaponDataComponent;
+
+    @Inject(
+        method = "postHit",
+        at = @At("HEAD"),
+        cancellable = true
+    )
+    private void storeSmashingWeaponDataComponent(ItemStack stack, LivingEntity target, LivingEntity attacker, CallbackInfo info, @Share("smashingWeapon") LocalRef<SmashingWeaponDataComponent> smashingWeapon) {
+        SmashingWeaponDataComponent smashingWeaponDataComponent = stack.get(ItematicDataComponentTypes.SMASHING_WEAPON);
+        if (smashingWeaponDataComponent == null) {
+            info.cancel();
+            return;
+        }
+
+        smashingWeapon.set(smashingWeaponDataComponent);
+    }
+
+    @Redirect(
+        method = "postHit",
+        at = @At(
+            value = "INVOKE",
+            target = "Lnet/minecraft/item/MaceItem;shouldDealAdditionalDamage(Lnet/minecraft/entity/LivingEntity;)Z"
+        )
+    )
+    private boolean shouldDealAdditionalDamageUseDataComponent(LivingEntity attacker, @Share("smashingWeapon") LocalRef<SmashingWeaponDataComponent> smashingWeapon) {
+        return smashingWeapon.get().canSmash(attacker);
+    }
+
+    @ModifyConstant(
+        method = "postHit",
+        constant = @Constant(
+            doubleValue = 5.0d
+        )
+    )
+    private double heavySmashAttackFallDistanceUseDataComponent(double constant, @Share("smashingWeapon") LocalRef<SmashingWeaponDataComponent> smashingWeapon) {
+        return smashingWeapon.get().heavySmashAttackFallDistance();
+    }
+
+    @Redirect(
+        method = "postHit",
+        at = @At(
+            value = "FIELD",
+            target = "Lnet/minecraft/sound/SoundEvents;ITEM_MACE_SMASH_GROUND_HEAVY:Lnet/minecraft/sound/SoundEvent;",
+            opcode = Opcodes.GETSTATIC
+        )
+    )
+    private SoundEvent getOnGroundLargeFallDistanceSoundUseDataComponent(@Share("smashingWeapon") LocalRef<SmashingWeaponDataComponent> smashingWeapon) {
+        return smashingWeapon.get()
+            .hitSounds()
+            .onGroundLargeFallDistance()
+            .value();
+    }
+
+    @Redirect(
+        method = "postHit",
+        at = @At(
+            value = "FIELD",
+            target = "Lnet/minecraft/sound/SoundEvents;ITEM_MACE_SMASH_GROUND:Lnet/minecraft/sound/SoundEvent;",
+            opcode = Opcodes.GETSTATIC
+        )
+    )
+    private SoundEvent getOnGroundSmallFallDistanceSoundUseDataComponent(@Share("smashingWeapon") LocalRef<SmashingWeaponDataComponent> smashingWeapon) {
+        return smashingWeapon.get()
+            .hitSounds()
+            .onGroundLargeFallDistance()
+            .value();
+    }
+
+    @ModifyArg(
+        method = "postHit",
+        at = @At(
+            value = "INVOKE",
+            target = "Lnet/minecraft/server/world/ServerWorld;playSound(Lnet/minecraft/entity/Entity;DDDLnet/minecraft/sound/SoundEvent;Lnet/minecraft/sound/SoundCategory;FF)V"
+        )
+    )
+    private SoundEvent getInAirSoundUseDataComponent(SoundEvent sound, @Share("smashingWeapon") LocalRef<SmashingWeaponDataComponent> smashingWeapon) {
+        return smashingWeapon.get()
+            .hitSounds()
+            .inAir()
+            .value();
+    }
+
+    @WrapOperation(
+        method = "postHit",
+        at = @At(
+            value = "INVOKE",
+            target = "Lnet/minecraft/item/MaceItem;knockbackNearbyEntities(Lnet/minecraft/world/World;Lnet/minecraft/entity/Entity;Lnet/minecraft/entity/Entity;)V"
+        )
+    )
+    private void temporarilyStoreUsedStack(World world, Entity attacker, Entity attacked, Operation<Void> original, @Share("smashingWeapon") LocalRef<SmashingWeaponDataComponent> smashingWeapon) {
+        usedStackSmashingWeaponDataComponent = smashingWeapon.get();
+        original.call(world, attacker, attacker);
+        usedStackSmashingWeaponDataComponent = null;
+    }
+
+    @Redirect(
+        method = "postDamageEntity",
+        at = @At(
+            value = "INVOKE",
+            target = "Lnet/minecraft/item/MaceItem;shouldDealAdditionalDamage(Lnet/minecraft/entity/LivingEntity;)Z"
+        )
+    )
+    private boolean shouldDealAdditionalDamageUseDataComponent(LivingEntity attacker, ItemStack stack) {
+        SmashingWeaponDataComponent smashingWeapon = stack.get(ItematicDataComponentTypes.SMASHING_WEAPON);
+        if (smashingWeapon == null) {
+            return false;
+        }
+
+        return smashingWeapon.canSmash(attacker);
+    }
+
+    @Redirect(
+        method = "getBonusAttackDamage",
+        at = @At(
+            value = "INVOKE",
+            target = "Lnet/minecraft/item/MaceItem;shouldDealAdditionalDamage(Lnet/minecraft/entity/LivingEntity;)Z"
+        )
+    )
+    private boolean shouldDealAdditionalDamageUseDataComponent(LivingEntity attacker) {
+        SmashingWeaponDataComponent smashingWeapon = Objects.requireNonNull(attacker.getWeaponStack())
+            .get(ItematicDataComponentTypes.SMASHING_WEAPON);
+        if (smashingWeapon == null) {
+            return false;
+        }
+
+        return smashingWeapon.canSmash(attacker);
+    }
+
+    @ModifyConstant(
+        method = "getKnockback",
+        constant = @Constant(
+            doubleValue = 5.0d
+        )
+    )
+    private static double heavySmashAttackFallDistanceUseDataComponent(double constant) {
+        return usedStackSmashingWeaponDataComponent.heavySmashAttackFallDistance();
+    }
+}

--- a/src/main/java/net/errorcraft/itematic/mixin/item/MaceItemExtender.java
+++ b/src/main/java/net/errorcraft/itematic/mixin/item/MaceItemExtender.java
@@ -152,6 +152,19 @@ public class MaceItemExtender {
     }
 
     @ModifyConstant(
+        method = {
+            "method_58409",
+            "getKnockback"
+        },
+        constant = @Constant(
+            doubleValue = 0.699999988079071d
+        )
+    )
+    private static double knockbackPowerUseDataComponent(double constant) {
+        return usedStackSmashingWeaponDataComponent.knockbackPower();
+    }
+
+    @ModifyConstant(
         method = "getKnockback",
         constant = @Constant(
             doubleValue = 5.0d

--- a/src/main/java/net/errorcraft/itematic/serialization/ItematicCodecs.java
+++ b/src/main/java/net/errorcraft/itematic/serialization/ItematicCodecs.java
@@ -11,12 +11,21 @@ public class ItematicCodecs {
         if (value >= 0 && value <= Float.MAX_VALUE) {
             return DataResult.success(value);
         }
+
         return DataResult.error(() -> "Value must be non-negative: " + value);
+    });
+    public static final Codec<Double> POSITIVE_DOUBLE = Codec.DOUBLE.validate(value -> {
+        if (value > 0 && value <= Double.MAX_VALUE) {
+            return DataResult.success(value);
+        }
+
+        return DataResult.error(() -> "Value must be positive: " + value);
     });
     public static final Codec<Double> NON_NEGATIVE_DOUBLE = Codec.DOUBLE.validate(value -> {
         if (value >= 0 && value <= Double.MAX_VALUE) {
             return DataResult.success(value);
         }
+
         return DataResult.error(() -> "Value must be non-negative: " + value);
     });
     public static final Codec<Integer> HUE = Codec.intRange(0, 360);
@@ -31,10 +40,12 @@ public class ItematicCodecs {
         if (size <= 0) {
             throw new IllegalArgumentException("size must be positive: " + size);
         }
+
         return Codec.INT.validate(i -> {
             if (i >= 0 && i <= size) {
                 return DataResult.success(i);
             }
+
             return DataResult.error(() -> "Index must be non-negative and less than " + size + ": " + i);
         });
     }
@@ -57,10 +68,12 @@ public class ItematicCodecs {
         if (maxInclusive <= 0) {
             throw new IllegalArgumentException("maxInclusive must be positive, got " + maxInclusive + " instead");
         }
+
         return POSITIVE_FRACTION.validate(fraction -> {
             if (fraction.intValue() > maxInclusive) {
                 return DataResult.error(() -> "Fraction must be at most " + maxInclusive);
             }
+
             return DataResult.success(fraction);
         });
     }

--- a/src/main/java/net/errorcraft/itematic/sound/SoundEventKeys.java
+++ b/src/main/java/net/errorcraft/itematic/sound/SoundEventKeys.java
@@ -37,6 +37,9 @@ public class SoundEventKeys {
     public static final RegistryKey<SoundEvent> HORSE_ARMOR_UNEQUIP = of("item.horse_armor.unequip");
     public static final RegistryKey<SoundEvent> HORSE_SADDLE = of("entity.horse.saddle");
     public static final RegistryKey<SoundEvent> LODESTONE_COMPASS_LOCK = of("item.lodestone_compass.lock");
+    public static final RegistryKey<SoundEvent> MACE_SMASH_AIR = of("item.mace.smash_air");
+    public static final RegistryKey<SoundEvent> MACE_SMASH_GROUND = of("item.mace.smash_ground");
+    public static final RegistryKey<SoundEvent> MACE_SMASH_GROUND_HEAVY = of("item.mace.smash_ground_heavy");
     public static final RegistryKey<SoundEvent> MUSIC_DISC_5 = of("music_disc.5");
     public static final RegistryKey<SoundEvent> MUSIC_DISC_11 = of("music_disc.11");
     public static final RegistryKey<SoundEvent> MUSIC_DISC_13 = of("music_disc.13");

--- a/src/main/resources/itematic.mixins.json
+++ b/src/main/resources/itematic.mixins.json
@@ -288,6 +288,8 @@
     "item.ItemStackExtender",
     "item.ItemUsageContextExtender",
     "item.KnowledgeBookItemExtender",
+    "item.MaceItemAccessor",
+    "item.MaceItemExtender",
     "item.RangedWeaponItemAccessor",
     "item.SmithingTemplateItemAccessor",
     "item.tooltip.BundleTooltipDataExtender",


### PR DESCRIPTION
Adds fields to the `minecraft:smashing` melee weapon component and adds a `minecraft:smashing_weapon` data component alongside it.
Fields for both the melee weapon component and data component:
- `hit_sounds`: A map with sounds. The sounds to play when hitting entities with a smashing attack.
  - `in_air`: A sound event. The sound to play when airborne.
  - `on_ground_small_fall_distance`: A sound event. The sound to play when dealing a regular smashing attack.
  - `on_ground_large_fall_distance`: A sound event. The sound to play when dealing a heavy smashing attack.
- `smash_attack_fall_distance`: A positive double. The minimum distance required to fall to deal a smashing attack.
- `heavy_smash_attack_fall_distance`: A positive double. The minimum distance required to fall to deal a heavy smashing attack.
- `knockback_power`: A positive double. The maximum knockback power to deal to nearby entities when dealing a smashing attack.

Example:
```json
{
  "heavy_smash_attack_fall_distance": 5.0,
  "hit_sounds": {
    "in_air": "minecraft:item.mace.smash_air",
    "on_ground_large_fall_distance": "minecraft:item.mace.smash_ground_heavy",
    "on_ground_small_fall_distance": "minecraft:item.mace.smash_ground"
  },
  "knockback_power": 0.699999988079071,
  "smash_attack_fall_distance": 1.5
}
```