### PR TITLE
Add the `minecraft:disables_blocking` melee weapon type

### DIFF
--- a/src/main/generated/data/minecraft/item/copper_axe.json
+++ b/src/main/generated/data/minecraft/item/copper_axe.json
@@ -29,8 +29,12 @@
         "rules": []
       },
       "attack_speed": 0.2,
-      "disable_blocking_for_seconds": 5.0,
-      "item_damage_per_attack": 2
+      "item_damage_per_attack": 2,
+      "types": {
+        "minecraft:disables_blocking": {
+          "seconds": 5.0
+        }
+      }
     }
   },
   "display": {

--- a/src/main/generated/data/minecraft/item/diamond_axe.json
+++ b/src/main/generated/data/minecraft/item/diamond_axe.json
@@ -29,8 +29,12 @@
         "rules": []
       },
       "attack_speed": 0.25,
-      "disable_blocking_for_seconds": 5.0,
-      "item_damage_per_attack": 2
+      "item_damage_per_attack": 2,
+      "types": {
+        "minecraft:disables_blocking": {
+          "seconds": 5.0
+        }
+      }
     }
   },
   "display": {

--- a/src/main/generated/data/minecraft/item/golden_axe.json
+++ b/src/main/generated/data/minecraft/item/golden_axe.json
@@ -29,8 +29,12 @@
         "rules": []
       },
       "attack_speed": 0.25,
-      "disable_blocking_for_seconds": 5.0,
-      "item_damage_per_attack": 2
+      "item_damage_per_attack": 2,
+      "types": {
+        "minecraft:disables_blocking": {
+          "seconds": 5.0
+        }
+      }
     }
   },
   "display": {

--- a/src/main/generated/data/minecraft/item/iron_axe.json
+++ b/src/main/generated/data/minecraft/item/iron_axe.json
@@ -29,8 +29,12 @@
         "rules": []
       },
       "attack_speed": 0.225,
-      "disable_blocking_for_seconds": 5.0,
-      "item_damage_per_attack": 2
+      "item_damage_per_attack": 2,
+      "types": {
+        "minecraft:disables_blocking": {
+          "seconds": 5.0
+        }
+      }
     }
   },
   "display": {

--- a/src/main/generated/data/minecraft/item/netherite_axe.json
+++ b/src/main/generated/data/minecraft/item/netherite_axe.json
@@ -32,8 +32,12 @@
         "rules": []
       },
       "attack_speed": 0.25,
-      "disable_blocking_for_seconds": 5.0,
-      "item_damage_per_attack": 2
+      "item_damage_per_attack": 2,
+      "types": {
+        "minecraft:disables_blocking": {
+          "seconds": 5.0
+        }
+      }
     }
   },
   "display": {

--- a/src/main/generated/data/minecraft/item/stone_axe.json
+++ b/src/main/generated/data/minecraft/item/stone_axe.json
@@ -29,8 +29,12 @@
         "rules": []
       },
       "attack_speed": 0.2,
-      "disable_blocking_for_seconds": 5.0,
-      "item_damage_per_attack": 2
+      "item_damage_per_attack": 2,
+      "types": {
+        "minecraft:disables_blocking": {
+          "seconds": 5.0
+        }
+      }
     }
   },
   "display": {

--- a/src/main/generated/data/minecraft/item/wooden_axe.json
+++ b/src/main/generated/data/minecraft/item/wooden_axe.json
@@ -32,8 +32,12 @@
         "rules": []
       },
       "attack_speed": 0.2,
-      "disable_blocking_for_seconds": 5.0,
-      "item_damage_per_attack": 2
+      "item_damage_per_attack": 2,
+      "types": {
+        "minecraft:disables_blocking": {
+          "seconds": 5.0
+        }
+      }
     }
   },
   "display": {

--- a/src/main/java/net/errorcraft/itematic/item/component/components/WeaponItemComponent.java
+++ b/src/main/java/net/errorcraft/itematic/item/component/components/WeaponItemComponent.java
@@ -10,6 +10,7 @@ import net.errorcraft.itematic.item.component.ItemComponentTypes;
 import net.errorcraft.itematic.item.event.ItemEvents;
 import net.errorcraft.itematic.item.weapon.melee.MeleeWeaponComponents;
 import net.errorcraft.itematic.item.weapon.melee.MeleeWeaponWithDataComponents;
+import net.errorcraft.itematic.item.weapon.melee.component.DisablesBlockingMeleeWeapon;
 import net.errorcraft.itematic.item.weapon.melee.component.KineticMeleeWeapon;
 import net.errorcraft.itematic.item.weapon.melee.component.SmashingMeleeWeapon;
 import net.errorcraft.itematic.serialization.ItematicCodecs;
@@ -38,10 +39,9 @@ import net.minecraft.world.World;
 import java.util.List;
 import java.util.Optional;
 
-public record WeaponItemComponent(int itemDamagePerAttack, float disableBlockingForSeconds, ComponentMap types, Optional<RegistryEntry<DamageType>> damageType, Optional<SwingAnimationComponent> swingAnimation, WeaponAttackDamageDataComponent attackDamage, double attackSpeed, Optional<AttackRangeComponent> attackRange, Optional<Float> minimumAttackCharge) implements ItemComponent<WeaponItemComponent>, ComponentHolder {
+public record WeaponItemComponent(int itemDamagePerAttack, ComponentMap types, Optional<RegistryEntry<DamageType>> damageType, Optional<SwingAnimationComponent> swingAnimation, WeaponAttackDamageDataComponent attackDamage, double attackSpeed, Optional<AttackRangeComponent> attackRange, Optional<Float> minimumAttackCharge) implements ItemComponent<WeaponItemComponent>, ComponentHolder {
     public static final Codec<WeaponItemComponent> CODEC = RecordCodecBuilder.create(instance -> instance.group(
         Codecs.NON_NEGATIVE_INT.optionalFieldOf("item_damage_per_attack", 1).forGetter(WeaponItemComponent::itemDamagePerAttack),
-        Codecs.NON_NEGATIVE_FLOAT.optionalFieldOf("disable_blocking_for_seconds", 0.0f).forGetter(WeaponItemComponent::disableBlockingForSeconds),
         MeleeWeaponComponents.CODEC.optionalFieldOf("types", ComponentMap.EMPTY).forGetter(WeaponItemComponent::types),
         DamageType.ENTRY_CODEC.optionalFieldOf("damage_type").forGetter(WeaponItemComponent::damageType),
         SwingAnimationComponent.CODEC.optionalFieldOf("swing_animation").forGetter(WeaponItemComponent::swingAnimation),
@@ -101,7 +101,11 @@ public record WeaponItemComponent(int itemDamagePerAttack, float disableBlocking
 
     @Override
     public void addComponents(ComponentMap.Builder builder) {
-        builder.add(DataComponentTypes.WEAPON, new WeaponComponent(this.itemDamagePerAttack, this.disableBlockingForSeconds));
+        DisablesBlockingMeleeWeapon disablesBlocking = this.types.get(MeleeWeaponComponents.DISABLES_BLOCKING);
+        builder.add(DataComponentTypes.WEAPON, new WeaponComponent(
+            this.itemDamagePerAttack,
+            disablesBlocking != null ? disablesBlocking.seconds() : 0.0f
+        ));
         builder.add(ItematicDataComponentTypes.WEAPON_ATTACK_DAMAGE, this.attackDamage);
         builder.add(ItematicDataComponentTypes.ATTACK_SPEED_MULTIPLIER, this.attackSpeed);
         this.streamAll(MeleeWeaponWithDataComponents.class)
@@ -151,7 +155,6 @@ public record WeaponItemComponent(int itemDamagePerAttack, float disableBlocking
         private final double attackSpeed;
         private AttackRangeComponent attackRange;
         private Float minimumAttackCharge;
-        private float disableBlockingForSeconds;
 
         private Builder(int itemDamagePerAttack, double attackDamage, double attackSpeed) {
             this.itemDamagePerAttack = itemDamagePerAttack;
@@ -162,7 +165,6 @@ public record WeaponItemComponent(int itemDamagePerAttack, float disableBlocking
         public WeaponItemComponent build() {
             return new WeaponItemComponent(
                 this.itemDamagePerAttack,
-                this.disableBlockingForSeconds,
                 this.types.build(),
                 Optional.ofNullable(this.damageType),
                 Optional.ofNullable(this.swingAnimation),
@@ -199,7 +201,10 @@ public record WeaponItemComponent(int itemDamagePerAttack, float disableBlocking
         }
 
         public Builder disableBlockingForSeconds(float disableBlockingForSeconds) {
-            this.disableBlockingForSeconds = disableBlockingForSeconds;
+            if (disableBlockingForSeconds > 0.0f) {
+                this.type(MeleeWeaponComponents.DISABLES_BLOCKING, new DisablesBlockingMeleeWeapon(disableBlockingForSeconds));
+            }
+
             return this;
         }
     }

--- a/src/main/java/net/errorcraft/itematic/item/weapon/melee/MeleeWeaponComponents.java
+++ b/src/main/java/net/errorcraft/itematic/item/weapon/melee/MeleeWeaponComponents.java
@@ -1,6 +1,7 @@
 package net.errorcraft.itematic.item.weapon.melee;
 
 import com.mojang.serialization.Codec;
+import net.errorcraft.itematic.item.weapon.melee.component.DisablesBlockingMeleeWeapon;
 import net.errorcraft.itematic.item.weapon.melee.component.KineticMeleeWeapon;
 import net.errorcraft.itematic.item.weapon.melee.component.PiercingMeleeWeapon;
 import net.errorcraft.itematic.item.weapon.melee.component.SmashingMeleeWeapon;
@@ -17,6 +18,7 @@ public class MeleeWeaponComponents {
     public static final ComponentType<SmashingMeleeWeapon> SMASHING = register("smashing", builder -> builder.codec(SmashingMeleeWeapon.CODEC));
     public static final ComponentType<KineticMeleeWeapon> KINETIC = register("kinetic", builder -> builder.codec(KineticMeleeWeapon.CODEC));
     public static final ComponentType<PiercingMeleeWeapon> PIERCING = register("piercing", builder -> builder.codec(PiercingMeleeWeapon.CODEC));
+    public static final ComponentType<DisablesBlockingMeleeWeapon> DISABLES_BLOCKING = register("disables_blocking", builder -> builder.codec(DisablesBlockingMeleeWeapon.CODEC));
 
     private MeleeWeaponComponents() {}
 

--- a/src/main/java/net/errorcraft/itematic/item/weapon/melee/component/DisablesBlockingMeleeWeapon.java
+++ b/src/main/java/net/errorcraft/itematic/item/weapon/melee/component/DisablesBlockingMeleeWeapon.java
@@ -1,0 +1,11 @@
+package net.errorcraft.itematic.item.weapon.melee.component;
+
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+import net.minecraft.util.dynamic.Codecs;
+
+public record DisablesBlockingMeleeWeapon(float seconds) {
+    public static final Codec<DisablesBlockingMeleeWeapon> CODEC = RecordCodecBuilder.create(instance -> instance.group(
+        Codecs.NON_NEGATIVE_FLOAT.fieldOf("seconds").forGetter(DisablesBlockingMeleeWeapon::seconds)
+    ).apply(instance, DisablesBlockingMeleeWeapon::new));
+}


### PR DESCRIPTION
Moves the `disable_blocking_for_seconds` field to a melee weapon type named `minecraft:disables_blocking`. The `disable_blocking_for_seconds` in the `minecraft:weapon` data component is still present and used to keep compatibility with existing data components.

So if you had this:
```json
{
  "attack_damage": {
    "default_damage": 9.0,
    "rules": []
  },
  "attack_speed": 0.225,
  "disable_blocking_for_seconds": 5.0,
  "item_damage_per_attack": 2
}
```
You now have to use this instead:
```json
{
  "attack_damage": {
    "default_damage": 9.0,
    "rules": []
  },
  "attack_speed": 0.225,
  "item_damage_per_attack": 2,
  "types": {
    "minecraft:disables_blocking": {
      "seconds": 5.0
    }
  }
}
```